### PR TITLE
Move cache to the GUI thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+ * Optimized how GUI and IO thread talk to each other.
+
 ## 0.4.0
 
 ### Breaking

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -58,7 +58,6 @@ impl Tiles {
         let tokio_runtime_thread = TokioRuntimeThread::new();
         let (tx, rx) = tokio::sync::mpsc::channel(5);
         let (tile_tx, tile_rx) = tokio::sync::mpsc::channel(5);
-        let cache = Arc::new(Mutex::new(HashMap::<TileId, Tile>::new()));
         tokio_runtime_thread
             .runtime
             .spawn(download(rx, tile_tx, egui_ctx));
@@ -71,7 +70,6 @@ impl Tiles {
     }
 
     pub fn at(&mut self, tile_id: TileId) -> Option<Tile> {
-        // TODO: get tiles
         if let Ok((tile_id, tile)) = self.tile_rx.try_recv() {
             self.cache.insert(tile_id, Some(tile));
         }

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -1,4 +1,3 @@
-use std::sync::Mutex;
 use std::{collections::HashMap, sync::Arc};
 
 use egui::{pos2, Color32, Context, Mesh, Rect, Vec2};


### PR DESCRIPTION
This way there is no need for a mutex-guarded map shared between threads.