### PR TITLE
Small changes to allow more mouse control (zoom with the wheel) of the widget

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,6 @@ mod tokio;
 mod zoom;
 
 pub use map::{Map, MapCenterMode, MapMemory};
-pub use mercator::{Position, PositionExt};
+pub use mercator::{Position, PositionExt, screen_to_position};
 pub use zoom::Zoom;
 pub use {tiles::openstreetmap, tiles::Tiles};

--- a/src/map.rs
+++ b/src/map.rs
@@ -87,10 +87,6 @@ impl MapCenterMode {
             MapCenterMode::Exact(position) => *position,
         }
     }
-
-    pub fn set_position(&mut self, position: Position) {
-        *self = MapCenterMode::Exact(position);
-    }
 }
 
 /// State of the map widget which must persist between frames.

--- a/src/map.rs
+++ b/src/map.rs
@@ -87,6 +87,10 @@ impl MapCenterMode {
             MapCenterMode::Exact(position) => *position,
         }
     }
+
+    pub fn set_position(&mut self, position: Position) {
+        *self = MapCenterMode::Exact(position);
+    }
 }
 
 /// State of the map widget which must persist between frames.


### PR DESCRIPTION
With this proposed changed one could use the widget to figure out LAT/LON locations of the point the mouse is currently at with something like

`
if let Some(mouse_position) = ui.input(|i| i.pointer.hover_pos()) {

    let current_position = match map_memory.center_mode {

        walkers::MapCenterMode::MyPosition => INITIAL_POSITION,

        walkers::MapCenterMode::Exact(p) => p,

    }

    .project(*map_memory.zoom);

    let relative_to_center_mouse_position = map_ui_rect.center() - mouse_position;

    let mouse = screen_to_position(

        current_position - relative_to_center_mouse_position,

        *map_memory.zoom,

    );

}
`

where `map_ui_rect` is the egui rect of the map widget.

It also allows to set the current center of the map by calling `set_position` with a LAT/LONG (or in the case of the example above `mouse`). Which in returns allows for a common map widget behaviour which is to zoom in on the location the mouse currently points to.