### PR TITLE
Update to egui 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,4 @@ version = "0.10.1"
 image = "*"
 log = "0.4"
 egui = "0.23"
-egui_extras = { version = "0.23", features = ["image"] }
 eframe = "0.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ members = ["walkers", "demo", "demo_native", "demo_web"]
 version = "0.10.1"
 
 [workspace.dependencies]
+image = "*"
 log = "0.4"
-egui = "0.22"
-egui_extras = { version = "0.22", features = ["image"] }
-eframe = "0.22"
+egui = "0.23"
+egui_extras = { version = "0.23", features = ["image"] }
+eframe = "0.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["walkers", "demo", "demo_native", "demo_web"]
 version = "0.11.0"
 
 [workspace.dependencies]
-image = "*"
+image = "0.24"
 log = "0.4"
 egui = "0.23"
 eframe = "0.23"

--- a/demo_native/Cargo.toml
+++ b/demo_native/Cargo.toml
@@ -6,6 +6,6 @@ publish = false
 
 [dependencies]
 demo = { path = "../demo" }
-eframe = "0.22"
-egui = "0.22"
+eframe = "0.23"
+egui = "0.23"
 env_logger = "0.10"

--- a/demo_web/Cargo.toml
+++ b/demo_web/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 demo = { path = "../demo" }
-eframe = "0.22"
-egui = "0.22"
+eframe = "0.23"
+egui = "0.23"
 log = "0.4"
 wasm-bindgen-futures = "0.4"

--- a/walkers/Cargo.toml
+++ b/walkers/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2021"
 [dependencies]
 log.workspace = true
 egui.workspace = true
-egui_extras.workspace = true
 thiserror = "1"
 image = { version = "0.24", features = ["jpeg", "png"] }
 geo-types = { version = "0.7" }

--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -1,8 +1,7 @@
 use std::collections::hash_map::Entry;
 use std::{collections::HashMap, sync::Arc};
 
-use egui::{pos2, Color32, Context, Mesh, Rect, Vec2};
-use egui_extras::RetainedImage;
+use egui::{pos2, Color32, ColorImage, Context, Mesh, mutex::Mutex, Rect, Vec2};
 
 use crate::download::download_continuously;
 use crate::io::Runtime;
@@ -16,6 +15,53 @@ pub(crate) fn rect(screen_position: Vec2) -> Rect {
     )
 }
 
+struct RetainedImage {
+    /// Cleared once [`Self::texture`] has been loaded.
+    image: Mutex<egui::ColorImage>,
+
+    /// Lazily loaded when we have an egui context.
+    texture: Mutex<Option<egui::TextureHandle>>,
+}
+
+fn load_image_bytes(image_bytes: &[u8]) -> Result<egui::ColorImage, String> {
+    let image = image::load_from_memory(image_bytes).map_err(|err| err.to_string())?;
+    let size = [image.width() as _, image.height() as _];
+    let image_buffer = image.to_rgba8();
+    let pixels = image_buffer.as_flat_samples();
+    Ok(egui::ColorImage::from_rgba_unmultiplied(
+        size,
+        pixels.as_slice(),
+    ))
+}
+
+impl RetainedImage {
+    fn from_color_image(image: ColorImage) -> Self {
+        Self {
+            image: Mutex::new(image),
+            texture: Default::default(),
+        }
+    }
+
+    fn from_image_bytes(
+        image_bytes: &[u8],
+    ) -> Result<Self, String> {
+        Ok(Self::from_color_image(
+            load_image_bytes(image_bytes)?,
+        ))
+    }
+
+    fn texture_id(&self, ctx: &egui::Context) -> egui::TextureId {
+        self.texture
+            .lock()
+            .get_or_insert_with(|| {
+                let image: &mut ColorImage = &mut self.image.lock();
+                let image = std::mem::take(image);
+                ctx.load_texture("tile", image, Default::default())
+            })
+            .id()
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct Tile {
     image: Arc<RetainedImage>,
@@ -23,7 +69,7 @@ pub(crate) struct Tile {
 
 impl Tile {
     pub fn from_image_bytes(image: &[u8]) -> Result<Self, String> {
-        RetainedImage::from_image_bytes("debug_name", image).map(|image| Self {
+        RetainedImage::from_image_bytes(image).map(|image| Self {
             image: Arc::new(image),
         })
     }

--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -1,7 +1,7 @@
 use std::collections::hash_map::Entry;
 use std::{collections::HashMap, sync::Arc};
 
-use egui::{pos2, Color32, ColorImage, Context, Mesh, mutex::Mutex, Rect, Vec2};
+use egui::{mutex::Mutex, pos2, Color32, ColorImage, Context, Mesh, Rect, Vec2};
 
 use crate::download::download_continuously;
 use crate::io::Runtime;
@@ -42,12 +42,8 @@ impl RetainedImage {
         }
     }
 
-    fn from_image_bytes(
-        image_bytes: &[u8],
-    ) -> Result<Self, String> {
-        Ok(Self::from_color_image(
-            load_image_bytes(image_bytes)?,
-        ))
+    fn from_image_bytes(image_bytes: &[u8]) -> Result<Self, String> {
+        Ok(Self::from_color_image(load_image_bytes(image_bytes)?))
     }
 
     fn texture_id(&self, ctx: &egui::Context) -> egui::TextureId {


### PR DESCRIPTION
A minimally invasive port to latest egui 0.23 API. The now deprecated `RetainedImage` from `egui_extras` has been replaced by a private copy of the code (only the essential parts). I realize that the latest egui introduced a new image loading API that could possibly replace large parts of the existing infrastructure in this crate. However, since I wasn't sure whether the maintainer of walkers is planning to go this route, and also since this would require a major refactoring, I thought it is better to leave this to a separate change.