### PR TITLE
Two small fixes

### DIFF
--- a/walkers/src/download.rs
+++ b/walkers/src/download.rs
@@ -1,5 +1,5 @@
 use egui::Context;
-use futures::StreamExt;
+use futures::{SinkExt, StreamExt};
 use image::ImageError;
 use reqwest::header::USER_AGENT;
 
@@ -59,7 +59,7 @@ where
 
         match download_and_decode(&client, &url, &egui_ctx).await {
             Ok(tile) => {
-                tile_tx.try_send((request, tile)).map_err(|_| ())?;
+                tile_tx.send((request, tile)).await.map_err(|_| ())?;
                 egui_ctx.request_repaint();
             }
             Err(e) => {

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -96,7 +96,7 @@ impl Map<'_, '_> {
 
         // Zooming and dragging need to be exclusive, otherwise the map will get dragged when
         // pinch gesture is used.
-        if !(0.99..=1.01).contains(&zoom_delta) {
+        if !(0.99..=1.01).contains(&zoom_delta) && ui.ui_contains_pointer() {
             // Displacement of mouse pointer relative to widget center
             let offset = response.hover_pos().map(|p| p - response.rect.center());
 

--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -111,7 +111,9 @@ impl Tiles {
             Err(_) => {
                 // Just ignore. It means that no new tile was downloaded.
             }
-            Ok(None) => panic!("IO thread is dead"),
+            Ok(None) => {
+                log::error!("IO thread is dead")
+            }
         }
 
         match self.cache.entry(tile_id) {


### PR DESCRIPTION
Fixes for two problems I encountered while [integrating walkers into our application](https://github.com/tudsat-rocket/sam/pull/12):

- By fullscreening the widget, violently moving the map around and also switching between tile providers, I was able to make the library panic by killing the IO thread. I assume this is happening because the channel for sending back the downloaded tiles is filling up. I fixed it by using the async version of `send`, and also downgrading the main thread's response from a panic to simply logging the death of the IO thread, since I don't want the entire application crashing because of that.
- The map was picking up scroll events when the pointer was outside of the map widget.