### PR TITLE
Add TileCache trait, incl. disk & noop implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
  * Fixed occasional panic when changing tile providers.
  * Fixed grabbing mouse events from outside the widget.
+ * Added `TileCache` trait for storage caches, as well as two implementations, `DiskTileCache` and
+   `NoopCache`.
+ * `Tiles::new` now expects a third argument, a `TileCache` implementation. Use `NoopCache {}` if
+   you do not need or want caching in your application.
 
 ## 0.13.0
 

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -9,3 +9,6 @@ walkers = { path = "../walkers" }
 eframe.workspace = true
 egui.workspace = true
 egui_extras.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+directories = "5.0.1"

--- a/walkers/README.md
+++ b/walkers/README.md
@@ -22,7 +22,7 @@ such as OpenStreetMap and stores them in a cache, `MapMemory` keeps track of
 the widget's state and `Map` is the widget itself.
 
 ```rust
-use walkers::{Tiles, Map, MapMemory, Position, providers::OpenStreetMap};
+use walkers::{Tiles, Map, MapMemory, Position, providers::OpenStreetMap, cache::NoopCache};
 use egui::{Context, CentralPanel};
 use eframe::{App, Frame};
 
@@ -34,7 +34,7 @@ struct MyApp {
 impl MyApp {
     fn new(egui_ctx: Context) -> Self {
         Self {
-            tiles: Tiles::new(OpenStreetMap, egui_ctx),
+            tiles: Tiles::new(OpenStreetMap, egui_ctx, NoopCache {}),
             map_memory: MapMemory::default(),
         }
     }

--- a/walkers/src/cache.rs
+++ b/walkers/src/cache.rs
@@ -1,0 +1,107 @@
+use std::fs::File;
+use std::hash::{Hash, Hasher};
+use std::io::{Read, Write};
+use std::path::PathBuf;
+
+use crate::mercator::TileId;
+use crate::providers::TileSource;
+
+/// Trait for custom cache implementations
+pub trait TileCache {
+    type Error;
+
+    fn read<S>(&mut self, provider: &S, tile_id: TileId) -> Result<Option<Vec<u8>>, Self::Error>
+    where
+        S: TileSource + Hash;
+
+    fn write<S>(&mut self, provider: &S, tile_id: TileId, data: &[u8]) -> Result<(), Self::Error>
+    where
+        S: TileSource + Hash;
+}
+
+/// A cache implementation that does nothing. Use this if you cannot or do not want to use another
+/// cache implementation, for instance on WebAssembly.
+#[derive(Debug, Clone)]
+pub struct NoopCache {}
+
+impl TileCache for NoopCache {
+    type Error = String;
+
+    fn read<S>(&mut self, _provider: &S, _tile_id: TileId) -> Result<Option<Vec<u8>>, Self::Error>
+    where
+        S: TileSource + Hash,
+    {
+        Ok(None)
+    }
+
+    fn write<S>(&mut self, _provider: &S, _tile_id: TileId, _data: &[u8]) -> Result<(), Self::Error>
+    where
+        S: TileSource + Hash,
+    {
+        Ok(())
+    }
+}
+
+/// A cache implementation storing tiles in a directory on-disk. Can safely be cloned and reused
+/// for different tile providers.
+#[derive(Debug, Clone)]
+pub struct DiskTileCache {
+    directory: PathBuf,
+}
+
+impl DiskTileCache {
+    pub fn new<P: Into<PathBuf>>(path: P) -> Self {
+        Self {
+            directory: path.into(),
+        }
+    }
+
+    fn cache_file_path<S>(&self, provider: &S, tile_id: TileId) -> PathBuf
+    where
+        S: TileSource + Hash,
+    {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        provider.hash(&mut hasher);
+        let provider_hash = hasher.finish();
+
+        self.directory
+            .join(format!("{:016x}", provider_hash))
+            .join(format!("{}_{}_{}", tile_id.zoom, tile_id.x, tile_id.y))
+    }
+}
+
+impl TileCache for DiskTileCache {
+    type Error = std::io::Error;
+
+    fn read<S>(&mut self, provider: &S, tile_id: TileId) -> Result<Option<Vec<u8>>, Self::Error>
+    where
+        S: TileSource + Hash,
+    {
+        let path = self.cache_file_path(provider, tile_id);
+        if path.exists() {
+            let mut f = File::open(path)?;
+            let mut buffer = Vec::new();
+            f.read_to_end(&mut buffer)?;
+            Ok(Some(buffer))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn write<S>(&mut self, provider: &S, tile_id: TileId, data: &[u8]) -> Result<(), Self::Error>
+    where
+        S: TileSource + Hash,
+    {
+        let path = self.cache_file_path(provider, tile_id);
+
+        // This should always succeed, given we created the path above
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir)?;
+        }
+
+        let mut f = File::create(path)?;
+        f.write_all(data)?;
+
+        Ok(())
+    }
+}

--- a/walkers/src/download.rs
+++ b/walkers/src/download.rs
@@ -1,84 +1,97 @@
+use std::hash::Hash;
+
 use egui::Context;
 use futures::{SinkExt, StreamExt};
-use image::ImageError;
 use reqwest::header::USER_AGENT;
 
-use crate::{mercator::TileId, providers::TileSource, tiles::Texture};
-
-#[derive(Debug, thiserror::Error)]
-enum Error {
-    #[error(transparent)]
-    Http(reqwest::Error),
-
-    #[error(transparent)]
-    Image(ImageError),
-}
+use crate::cache::TileCache;
+use crate::mercator::TileId;
+use crate::providers::TileSource;
+use crate::tiles::Texture;
 
 /// Download and decode the tile.
-async fn download_and_decode(
-    client: &reqwest::Client,
-    url: &str,
-    egui_ctx: &Context,
-) -> Result<Texture, Error> {
-    let image = client
-        .get(url)
-        .header(USER_AGENT, "Walkers")
-        .send()
-        .await
-        .map_err(Error::Http)?;
+async fn download_tile(client: &reqwest::Client, url: &str) -> Result<Vec<u8>, reqwest::Error> {
+    let image = client.get(url).header(USER_AGENT, "Walkers").send().await?;
 
     log::debug!("Downloaded {:?}.", image.status());
 
-    let image = image
-        .error_for_status()
-        .map_err(Error::Http)?
-        .bytes()
-        .await
-        .map_err(Error::Http)?;
+    let image = image.error_for_status()?.bytes().await?;
 
-    Texture::new(&image, egui_ctx).map_err(Error::Image)
+    Ok(image.to_vec())
 }
 
-async fn download_continuously_impl<S>(
+async fn download_continuously_impl<C, S>(
     source: S,
+    mut cache: C,
     mut request_rx: futures::channel::mpsc::Receiver<TileId>,
     mut tile_tx: futures::channel::mpsc::Sender<(TileId, Texture)>,
     egui_ctx: Context,
 ) -> Result<(), ()>
 where
-    S: TileSource + Send + 'static,
+    C: TileCache + Send + 'static,
+    C::Error: std::fmt::Display,
+    S: TileSource + Hash + Send + 'static,
 {
     // Keep outside the loop to reuse it as much as possible.
     let client = reqwest::Client::new();
 
     loop {
         let request = request_rx.next().await.ok_or(())?;
-        let url = source.tile_url(request);
 
-        log::debug!("Getting {:?} from {}.", request, url);
-
-        match download_and_decode(&client, &url, &egui_ctx).await {
-            Ok(tile) => {
-                tile_tx.send((request, tile)).await.map_err(|_| ())?;
-                egui_ctx.request_repaint();
-            }
+        let cached_bytes = match cache.read(&source, request) {
+            Ok(cached) => cached,
             Err(e) => {
-                log::warn!("Could not download '{}': {}", &url, e);
+                log::warn!("Failed to load tile from cache: {}.", e);
+                None
+            }
+        };
+
+        let bytes = if let Some(bytes) = cached_bytes {
+            Some(bytes)
+        } else {
+            let url = source.tile_url(request);
+            log::debug!("Getting {:?} from {}.", request, url);
+            match download_tile(&client, &url).await {
+                Ok(bytes) => {
+                    if let Err(e) = cache.write(&source, request, &bytes) {
+                        log::warn!("Failed to write tile to cache: {}", e);
+                    }
+                    Some(bytes)
+                }
+                Err(e) => {
+                    log::warn!("Could not download '{}': {}", &url, e);
+                    None
+                }
+            }
+        };
+
+        if let Some(bytes) = bytes {
+            match Texture::new(&bytes, &egui_ctx) {
+                Ok(tile) => {
+                    tile_tx.send((request, tile)).await.map_err(|_| ())?;
+                    egui_ctx.request_repaint();
+                }
+                Err(e) => {
+                    log::warn!("Failed to decode image: {}", e);
+                }
             }
         }
     }
 }
 
 /// Continuously download tiles requested via request channel.
-pub(crate) async fn download_continuously<S>(
+pub(crate) async fn download_continuously<C, S>(
     source: S,
+    cache: C,
     request_rx: futures::channel::mpsc::Receiver<TileId>,
     tile_tx: futures::channel::mpsc::Sender<(TileId, Texture)>,
     egui_ctx: Context,
 ) where
-    S: TileSource + Send + 'static,
+    C: TileCache + Send + 'static,
+    C::Error: std::fmt::Display,
+    S: TileSource + Hash + Send + 'static,
 {
-    if download_continuously_impl(source, request_rx, tile_tx, egui_ctx)
+    if download_continuously_impl(source, cache, request_rx, tile_tx, egui_ctx)
         .await
         .is_err()
     {

--- a/walkers/src/lib.rs
+++ b/walkers/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![deny(clippy::unwrap_used, rustdoc::broken_intra_doc_links)]
 
+pub mod cache;
 mod download;
 pub mod extras;
 mod io;

--- a/walkers/src/providers.rs
+++ b/walkers/src/providers.rs
@@ -1,5 +1,7 @@
 //! Some common tile map providers.
 
+use std::hash::Hash;
+
 use crate::mercator::TileId;
 
 #[derive(Clone)]
@@ -21,6 +23,7 @@ pub trait TileSource {
 }
 
 /// <https://www.openstreetmap.org/about>
+#[derive(Hash)]
 pub struct OpenStreetMap;
 
 impl TileSource for OpenStreetMap {
@@ -43,6 +46,7 @@ impl TileSource for OpenStreetMap {
 
 /// Orthophotomap layer from Poland's Geoportal.
 /// <https://www.geoportal.gov.pl/uslugi/usluga-przegladania-wms>
+#[derive(Hash)]
 pub struct Geoportal;
 
 impl TileSource for Geoportal {
@@ -73,7 +77,7 @@ impl TileSource for Geoportal {
 
 /// Predefined Mapbox styles.
 /// <https://docs.mapbox.com/api/maps/styles/#classic-mapbox-styles>
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, Hash)]
 pub enum MapboxStyle {
     #[default]
     Streets,
@@ -103,7 +107,7 @@ impl MapboxStyle {
 
 /// Mapbox static tile source.
 /// <https://docs.mapbox.com/api/maps/static-tiles/>
-#[derive(Default)]
+#[derive(Default, Hash)]
 pub struct Mapbox {
     /// Predefined style to use
     pub style: MapboxStyle,


### PR DESCRIPTION
Adds a trait for caching along the lines of `TileSource`, as well as two default implementations, a simple `DiskTileCache`, as well as a `NoopCache` that does nothing. The demo has been updated to use `DiskTileCache` in native, and `ǸoopCache` for wasm.

Because I needed some way to differentiate between different tile providers, this introduces the requirement that tile providers implement `Hash`.

This is a lot more code and probably less elegant than @dwuertz's idea with `http-cache-reqwest` in #64, but it might be more flexible. For instance, an Android application could implement a cache provider that uses some sort of Android API via the JNI.

I'm definitely open to suggestions on how to do this nicer, though. I don't like how it has to be passed to the Tiles constructor, but since the background thread is spawned immediately some sort of builder pattern would require some more refactoring.