### PR TITLE
Ability to specify zoom steps and limits per TilesManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
  * `egui` updated to 0.24. This change requires Rust 1.72 or greater.
  * `TileManager` trait and demonstration of local-generated rainbowed tiles
  * Click to set position in demo
+ * Different zoom levels limit for local-generated tiles and remote
 
 ## 0.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
  * `egui` updated to 0.24. This change requires Rust 1.72 or greater.
  * `TileManager` trait and demonstration of local-generated rainbowed tiles
+ * Click to set position in demo
 
 ## 0.14.0
 

--- a/demo/src/local_tiles.rs
+++ b/demo/src/local_tiles.rs
@@ -34,4 +34,8 @@ impl TilesManager for LocalTiles {
     fn tile_size(&self) -> u32 {
         256
     }
+
+    fn available_zoom(&self) -> Vec<u8> {
+        return Vec::from_iter(0..23);
+    }
 }

--- a/demo/src/plugins.rs
+++ b/demo/src/plugins.rs
@@ -1,7 +1,9 @@
+use std::{cell::Cell, rc::Rc};
+
 use egui::{Color32, Painter, Response};
 use walkers::{
     extras::{Image, Images, Place, Places, Style, Texture},
-    Plugin, Projector,
+    Plugin, Position, Projector,
 };
 
 use crate::places;
@@ -76,5 +78,19 @@ impl Plugin for CustomShapes {
             radius,
             Color32::BLACK.gamma_multiply(if hovered { 0.5 } else { 0.2 }),
         );
+    }
+}
+
+pub struct ClickWatcher {
+    pub last_click: Rc<Cell<Option<Position>>>,
+}
+
+impl Plugin for ClickWatcher {
+    fn draw(&self, response: &Response, _painter: Painter, projector: &Projector) {
+        if response.clicked_by(egui::PointerButton::Primary) {
+            if let Some(offset) = response.hover_pos().map(|p| p - response.rect.center()) {
+                self.last_click.set(Some(projector.reverse(offset)));
+            }
+        }
     }
 }

--- a/demo/src/windows.rs
+++ b/demo/src/windows.rs
@@ -2,7 +2,7 @@ use crate::plugins::ImagesPluginData;
 
 use crate::Provider;
 use egui::{Align2, RichText, Ui, Window};
-use walkers::{providers::Attribution, MapMemory};
+use walkers::{providers::Attribution, MapMemory, Position};
 
 pub fn acknowledge(ui: &Ui, attribution: Attribution) {
     Window::new("Acknowledge")
@@ -90,4 +90,20 @@ pub fn go_to_my_position(ui: &Ui, map_memory: &mut MapMemory) {
                 }
             });
     }
+}
+
+pub fn show_my_position(ui: &Ui, my_position: &Position) {
+    Window::new("My Position")
+        .collapsible(false)
+        .resizable(false)
+        .title_bar(false)
+        .anchor(Align2::CENTER_BOTTOM, [0., -10.])
+        .show(ui.ctx(), |ui| {
+            ui.label(format!(
+                "{:.04} {:.04}",
+                my_position.lon(),
+                my_position.lat()
+            ))
+            .on_hover_text("my position");
+        });
 }

--- a/demo/src/windows.rs
+++ b/demo/src/windows.rs
@@ -64,6 +64,8 @@ pub fn zoom(ui: &Ui, map_memory: &mut MapMemory) {
                     let _ = map_memory.zoom_in();
                 }
 
+                ui.label(format!("{:^3}", map_memory.zoom_get()));
+
                 if ui.button(RichText::new("➖").heading()).clicked() {
                     let _ = map_memory.zoom_out();
                 }

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -371,6 +371,11 @@ impl MapMemory {
         self.zoom.zoom_out()
     }
 
+    /// Get current zoom level
+    pub fn zoom_get(&self) -> u8 {
+        self.zoom.round()
+    }
+
     /// Returns exact position if map is detached (i.e. not following `my_position`),
     /// `None` otherwise.
     pub fn detached(&self) -> Option<Position> {

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -45,6 +45,9 @@ impl<'a, 'b, 'c> Map<'a, 'b, 'c> {
         memory: &'a mut MapMemory,
         my_position: Position,
     ) -> Self {
+        if let Some(tiles) = &tiles {
+            memory.zoom_set_limit(tiles.available_zoom());
+        }
         Self {
             tiles,
             memory,
@@ -352,6 +355,10 @@ pub struct MapMemory {
 }
 
 impl MapMemory {
+    pub(super) fn zoom_set_limit(&mut self, available_zoom: Vec<u8>) {
+        self.zoom.limit_set(available_zoom);
+    }
+
     /// Try to zoom in, returning `Err(InvalidZoom)` if already at maximum.
     pub fn zoom_in(&mut self) -> Result<(), InvalidZoom> {
         self.center_mode = self.center_mode.clone().zero_offset(self.zoom.round());

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -87,6 +87,20 @@ impl Projector {
         self.clip_rect.center().to_vec2()
             + (projected_position - map_center_projected_position).to_vec2()
     }
+
+    /// Get coordinates from viewport's pixels position
+    pub fn reverse(&self, position: Vec2) -> Position {
+        let zoom = self.memory.zoom.round();
+
+        let center = self.memory.center_mode.position(self.my_position, zoom);
+
+        AdjustedPosition {
+            position: center,
+            offset: Default::default(),
+        }
+        .shift(-position)
+        .position(zoom)
+    }
 }
 
 impl Map<'_, '_, '_> {

--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -57,6 +57,7 @@ pub trait TilesManager {
     fn at(&mut self, tile_id: TileId) -> Option<Texture>;
     fn attribution(&self) -> Attribution;
     fn tile_size(&self) -> u32;
+    fn available_zoom(&self) -> Vec<u8>;
 }
 
 /// Downloads and keeps cache of the tiles. It must persist between frames.
@@ -140,6 +141,10 @@ impl TilesManager for Tiles {
 
     fn tile_size(&self) -> u32 {
         self.tile_size
+    }
+
+    fn available_zoom(&self) -> Vec<u8> {
+        return Vec::from_iter(0..=19);
     }
 }
 

--- a/walkers/src/zoom.rs
+++ b/walkers/src/zoom.rs
@@ -2,48 +2,69 @@
 #[error("invalid zoom level")]
 pub struct InvalidZoom;
 
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct Zoom(f32);
-
-impl TryFrom<f32> for Zoom {
-    type Error = InvalidZoom;
-
-    fn try_from(value: f32) -> Result<Self, Self::Error> {
-        // Mapnik supports zooms up to 19.
-        // https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Zoom_levels
-        if !(0. ..=19.).contains(&value) {
-            Err(InvalidZoom)
-        } else {
-            Ok(Self(value))
-        }
-    }
+#[derive(Debug, Clone)]
+pub(crate) struct Zoom {
+    value: f32,
+    limits: Vec<u8>,
 }
 
 impl Default for Zoom {
     fn default() -> Self {
-        Self(16.)
+        Self {
+            value: 16.,
+            // Mapnik supports zooms up to 19.
+            // https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Zoom_levels
+            limits: Vec::from_iter(0..=19),
+        }
     }
 }
 
 impl Zoom {
+    pub fn limit_set(&mut self, limits: Vec<u8>) {
+        self.limits = limits;
+        self.zoom_set(self.value).unwrap_or_default();
+    }
+
     pub fn round(&self) -> u8 {
-        self.0.round() as u8
+        self.value.round() as u8
     }
 
     pub fn zoom_in(&mut self) -> Result<(), InvalidZoom> {
-        *self = Self::try_from(self.0 + 1.)?;
+        self.zoom_set(self.value + 1.)?;
         Ok(())
     }
 
     pub fn zoom_out(&mut self) -> Result<(), InvalidZoom> {
-        *self = Self::try_from(self.0 - 1.)?;
+        self.zoom_set(self.value - 1.)?;
         Ok(())
     }
 
     /// Zoom using a relative value.
     pub fn zoom_by(&mut self, value: f32) {
-        if let Ok(new_self) = Self::try_from(self.0 + value) {
-            *self = new_self;
+        self.zoom_set(self.value + value).unwrap_or_default();
+    }
+
+    /// Zoom using a absolute value.
+    pub fn zoom_set(&mut self, value: f32) -> Result<Self, InvalidZoom> {
+        if value < (*self.limits.first().unwrap() as f32) {
+            self.value = *self.limits.first().unwrap() as f32;
+            Err(InvalidZoom)
+        } else if value > (*self.limits.last().unwrap() as f32) {
+            self.value = *self.limits.last().unwrap() as f32;
+            Err(InvalidZoom)
+        } else if !self.limits.contains(&(value.round() as u8)) {
+            let rounded_value = value.round() as u8;
+
+            for idx in 1..self.limits.len() {
+                if rounded_value > self.limits[idx - 1] && rounded_value < self.limits[idx] {
+                    self.value = self.limits[idx - 1] as f32;
+                    break;
+                }
+            }
+            Ok(self.clone())
+        } else {
+            self.value = value;
+            Ok(self.clone())
         }
     }
 }
@@ -55,13 +76,13 @@ mod tests {
     #[test]
     fn test_constructing_zoom() {
         assert_eq!(16, Zoom::default().round());
-        assert_eq!(19, Zoom::try_from(19.).unwrap().round());
-        assert_eq!(InvalidZoom, Zoom::try_from(20.).unwrap_err());
+        assert_eq!(19, Zoom::default().zoom_set(19.).unwrap().round());
+        assert_eq!(InvalidZoom, Zoom::default().zoom_set(20.).unwrap_err());
     }
 
     #[test]
     fn test_zooming_in() {
-        let mut zoom = Zoom::try_from(18.).unwrap();
+        let mut zoom = Zoom::default().zoom_set(18.).unwrap();
         assert!(zoom.zoom_in().is_ok());
         assert_eq!(19, zoom.round());
         assert_eq!(Err(InvalidZoom), zoom.zoom_in());
@@ -69,9 +90,22 @@ mod tests {
 
     #[test]
     fn test_zooming_out() {
-        let mut zoom = Zoom::try_from(1.).unwrap();
+        let mut zoom = Zoom::default().zoom_set(1.).unwrap();
         assert!(zoom.zoom_out().is_ok());
         assert_eq!(0, zoom.round());
         assert_eq!(Err(InvalidZoom), zoom.zoom_out());
+    }
+
+    #[test]
+    fn test_set_limit() {
+        let mut zoom = Zoom::default();
+        zoom.zoom_by(16.0);
+        zoom.limit_set(Vec::from_iter(0..=14));
+        assert_eq!(zoom.round(), 14);
+        zoom.limit_set(Vec::from_iter(16..=21));
+        assert_eq!(zoom.round(), 16);
+        zoom.zoom_by(4.4);
+        zoom.limit_set(vec![17, 19, 23, 24]);
+        assert_eq!(zoom.round(), 19);
     }
 }


### PR DESCRIPTION
Now is possible to:
1. Iterate other zoom step instead (e.g. z1 .. z3 ... z4 ... z5) if source is describes it
2. specifiy different zoms for each TilesManager

upstream branch is `click` in noktoborus/walkers repo