### PR TITLE
Http cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ Cargo.lock
 /demo_android/java/.gradle
 /demo_android/java/app/build
 /demo_android/java/app/src/main/jniLibs
+
+# Path where `demo_native` stores the HTTP cache.
+.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+ * HTTP cache can be now enabled on native platforms (in WASM, is it handled by the browser).
  * `TileManager` trait and demonstration of locally generated tiles.
 
 ## 0.15.0

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -19,12 +19,12 @@ pub enum Provider {
 }
 
 fn http_options() -> HttpOptions {
-    if std::env::var("NO_HTTP_CACHE").is_ok() {
-        HttpOptions::default()
-    } else {
-        HttpOptions {
-            cache: Some(".cache".into()),
-        }
+    HttpOptions {
+        cache: if std::env::var("NO_HTTP_CACHE").is_ok() {
+            None
+        } else {
+            Some(".cache".into())
+        },
     }
 }
 

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -17,8 +17,12 @@ pub enum Provider {
 }
 
 fn http_options() -> HttpOptions {
-    HttpOptions {
-        cache: Some(".cache".into()),
+    if std::env::var("NO_HTTP_CACHE").is_ok() {
+        HttpOptions::default()
+    } else {
+        HttpOptions {
+            cache: Some(".cache".into()),
+        }
     }
 }
 

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 use crate::plugins::ImagesPluginData;
 use egui::Context;
-use walkers::{Map, MapMemory, Tiles};
+use walkers::{HttpOptions, Map, MapMemory, Tiles};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Provider {
@@ -16,17 +16,31 @@ pub enum Provider {
     MapboxSatellite,
 }
 
+fn http_options() -> HttpOptions {
+    HttpOptions {
+        cache: Some(".cache".into()),
+    }
+}
+
 fn providers(egui_ctx: Context) -> HashMap<Provider, Tiles> {
     let mut providers = HashMap::default();
 
     providers.insert(
         Provider::OpenStreetMap,
-        Tiles::new(walkers::providers::OpenStreetMap, egui_ctx.to_owned()),
+        Tiles::with_options(
+            walkers::providers::OpenStreetMap,
+            http_options(),
+            egui_ctx.to_owned(),
+        ),
     );
 
     providers.insert(
         Provider::Geoportal,
-        Tiles::new(walkers::providers::Geoportal, egui_ctx.to_owned()),
+        Tiles::with_options(
+            walkers::providers::Geoportal,
+            http_options(),
+            egui_ctx.to_owned(),
+        ),
     );
 
     // Pass in a mapbox access token at compile time. May or may not be what you want to do,
@@ -37,24 +51,26 @@ fn providers(egui_ctx: Context) -> HashMap<Provider, Tiles> {
     if let Some(token) = mapbox_access_token {
         providers.insert(
             Provider::MapboxStreets,
-            Tiles::new(
+            Tiles::with_options(
                 walkers::providers::Mapbox {
                     style: walkers::providers::MapboxStyle::Streets,
                     access_token: token.to_string(),
                     high_resolution: false,
                 },
+                http_options(),
                 egui_ctx.to_owned(),
             ),
         );
 
         providers.insert(
             Provider::MapboxSatellite,
-            Tiles::new(
+            Tiles::with_options(
                 walkers::providers::Mapbox {
                     style: walkers::providers::MapboxStyle::Satellite,
                     access_token: token.to_string(),
                     high_resolution: true,
                 },
+                http_options(),
                 egui_ctx.to_owned(),
             ),
         );

--- a/walkers/Cargo.toml
+++ b/walkers/Cargo.toml
@@ -20,7 +20,6 @@ reqwest = { version = "0.11", default-features = false, features = [
     "rustls-tls",
 ] }
 futures = "0.3.28"
-http-cache-reqwest = "0.12.0"
 reqwest-middleware = "0.2.4"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
@@ -28,6 +27,7 @@ wasm-bindgen-futures = "0.4.37"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokio = { version = "1.28", features = ["macros"] }
+http-cache-reqwest = "0.12.0"
 
 [dev-dependencies]
 eframe.workspace = true

--- a/walkers/Cargo.toml
+++ b/walkers/Cargo.toml
@@ -20,6 +20,8 @@ reqwest = { version = "0.11", default-features = false, features = [
     "rustls-tls",
 ] }
 futures = "0.3.28"
+http-cache-reqwest = "0.12.0"
+reqwest-middleware = "0.2.4"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 wasm-bindgen-futures = "0.4.37"

--- a/walkers/src/download.rs
+++ b/walkers/src/download.rs
@@ -14,7 +14,7 @@ pub struct HttpOptions {
     ///
     /// Keep in mind that some providers (such as OpenStreetMap) require clients
     /// to respect the HTTP `Expires` header.
-    /// https://operations.osmfoundation.org/policies/tiles/
+    /// <https://operations.osmfoundation.org/policies/tiles/>
     ///
     /// This option is ignored in WASM, as HTTP cache is controlled by the
     /// browser the app is running on.

--- a/walkers/src/download.rs
+++ b/walkers/src/download.rs
@@ -16,10 +16,10 @@ pub struct HttpOptions {
 #[derive(Debug, thiserror::Error)]
 enum Error {
     #[error(transparent)]
-    Http(reqwest_middleware::Error),
+    HttpMiddleware(reqwest_middleware::Error),
 
     #[error(transparent)]
-    Http2(reqwest::Error),
+    Http(reqwest::Error),
 
     #[error(transparent)]
     Image(ImageError),
@@ -36,16 +36,16 @@ async fn download_and_decode(
         .header(USER_AGENT, "Walkers")
         .send()
         .await
-        .map_err(Error::Http)?;
+        .map_err(Error::HttpMiddleware)?;
 
     log::debug!("Downloaded {:?}.", image.status());
 
     let image = image
         .error_for_status()
-        .map_err(Error::Http2)?
+        .map_err(Error::Http)?
         .bytes()
         .await
-        .map_err(Error::Http2)?;
+        .map_err(Error::Http)?;
 
     Texture::new(&image, egui_ctx).map_err(Error::Image)
 }

--- a/walkers/src/download.rs
+++ b/walkers/src/download.rs
@@ -10,6 +10,14 @@ use crate::{io::http_client, mercator::TileId, providers::TileSource, tiles::Tex
 
 #[derive(Default)]
 pub struct HttpOptions {
+    /// Path to the directory to store the HTTP cache.
+    ///
+    /// Keep in mind that some providers (such as OpenStreetMap) require clients
+    /// to respect the HTTP `Expires` header.
+    /// https://operations.osmfoundation.org/policies/tiles/
+    ///
+    /// This option is ignored in WASM, as HTTP cache is controlled by the
+    /// browser the app is running on.
     pub cache: Option<PathBuf>,
 }
 

--- a/walkers/src/download.rs
+++ b/walkers/src/download.rs
@@ -8,6 +8,7 @@ use reqwest_middleware::ClientWithMiddleware;
 
 use crate::{io::http_client, mercator::TileId, providers::TileSource, tiles::Texture};
 
+/// Controls how [`crate::Tiles`] use the HTTP protocol, such as caching.
 #[derive(Default)]
 pub struct HttpOptions {
     /// Path to the directory to store the HTTP cache.

--- a/walkers/src/io.rs
+++ b/walkers/src/io.rs
@@ -80,14 +80,17 @@ mod native {
     }
 
     pub fn http_client(http_options: HttpOptions) -> ClientWithMiddleware {
-        ClientBuilder::new(reqwest::Client::new())
-            .with(Cache(HttpCache {
+        let builder = ClientBuilder::new(reqwest::Client::new());
+
+        if let Some(cache) = http_options.cache {
+            builder.with(Cache(HttpCache {
                 mode: CacheMode::Default,
-                manager: CACacheManager {
-                    path: http_options.cache.unwrap(),
-                },
+                manager: CACacheManager { path: cache },
                 options: HttpCacheOptions::default(),
             }))
-            .build()
+        } else {
+            builder
+        }
+        .build()
     }
 }

--- a/walkers/src/io.rs
+++ b/walkers/src/io.rs
@@ -8,7 +8,8 @@ pub use web::*;
 
 #[cfg(target_arch = "wasm32")]
 mod web {
-    use reqwest_middleware::ClientWithMiddleware;
+    use crate::HttpOptions;
+    use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 
     pub struct Runtime;
 
@@ -22,7 +23,7 @@ mod web {
         }
     }
 
-    pub fn http_client(http_options: HttpOptions) -> ClientWithMiddleware {
+    pub fn http_client(_http_options: HttpOptions) -> ClientWithMiddleware {
         ClientBuilder::new(reqwest::Client::new()).build()
     }
 }

--- a/walkers/src/io.rs
+++ b/walkers/src/io.rs
@@ -23,7 +23,10 @@ mod web {
         }
     }
 
-    pub fn http_client(_http_options: HttpOptions) -> ClientWithMiddleware {
+    pub fn http_client(http_options: HttpOptions) -> ClientWithMiddleware {
+        if http_options.cache.is_some() {
+            log::warn!("HTTP cache directory set, but ignored because, in WASM, caching is handled by the browser.");
+        }
         ClientBuilder::new(reqwest::Client::new()).build()
     }
 }

--- a/walkers/src/lib.rs
+++ b/walkers/src/lib.rs
@@ -10,6 +10,7 @@ pub mod providers;
 mod tiles;
 mod zoom;
 
+pub use download::HttpOptions;
 pub use map::{Map, MapMemory, Plugin, Projector};
 pub use mercator::{screen_to_position, Position};
 pub use tiles::Tiles;

--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -78,6 +78,7 @@ pub struct Tiles {
 }
 
 impl Tiles {
+    /// Construct new [`Tiles`] with default [`HttpOptions`].
     pub fn new<S>(source: S, egui_ctx: Context) -> Self
     where
         S: TileSource + Send + 'static,
@@ -85,6 +86,7 @@ impl Tiles {
         Self::with_options(source, HttpOptions::default(), egui_ctx)
     }
 
+    /// Construct new [`Tiles`] with supplied [`HttpOptions`].
     pub fn with_options<S>(source: S, http_options: HttpOptions, egui_ctx: Context) -> Self
     where
         S: TileSource + Send + 'static,

--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -59,7 +59,7 @@ pub trait TilesManager {
     fn tile_size(&self) -> u32;
 }
 
-/// Downloads and keeps cache of the tiles. It must persist between frames.
+/// Downloads the tiles via HTTP. It must persist between frames.
 pub struct Tiles {
     attribution: Attribution,
 


### PR DESCRIPTION
Used `http-cache-reqwest` to implement caching. It works only on native platforms (PC, Android). In WASM, caching is handled by the browser and `http-cache-reqwest` doesn't even compile, hence the platform specific HTTP client builders in `mod io`.

closes https://github.com/podusowski/walkers/issues/64