### PR TITLE
add option to disable map's input and know if map handles gesture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
  * `mod providers` is now called `mod sources`, to resemble `trait TileSource`.
  * HTTP cache can be now enabled on native platforms (in WASM, is it handled by the browser).
  * `TileManager` trait and demonstration of locally generated tiles.
+ * Map: add ability to disable zoom and drag gestures
+ * Map plugins: add `gesture_handled` flag to let plugins know if it the map's gesture
 
 ## 0.15.0
 

--- a/demo/src/plugins.rs
+++ b/demo/src/plugins.rs
@@ -57,7 +57,13 @@ pub fn images(images_plugin_data: &mut ImagesPluginData) -> impl Plugin {
 pub struct CustomShapes {}
 
 impl Plugin for CustomShapes {
-    fn draw(&self, response: &Response, painter: Painter, projector: &Projector) {
+    fn draw(
+        &self,
+        response: &Response,
+        _gesture_handled: bool,
+        painter: Painter,
+        projector: &Projector,
+    ) {
         // Position of the point we want to put our shapes.
         let position = places::capitol();
 

--- a/walkers/src/extras/images.rs
+++ b/walkers/src/extras/images.rs
@@ -60,7 +60,13 @@ impl Images {
 }
 
 impl Plugin for Images {
-    fn draw(&self, response: &Response, painter: Painter, projector: &crate::Projector) {
+    fn draw(
+        &self,
+        response: &Response,
+        _gesture_handled: bool,
+        painter: Painter,
+        projector: &crate::Projector,
+    ) {
         for image in &self.images {
             image.draw(response, painter.clone(), projector);
         }

--- a/walkers/src/extras/places.rs
+++ b/walkers/src/extras/places.rs
@@ -45,7 +45,13 @@ pub struct Place {
 }
 
 impl Place {
-    fn draw(&self, _response: &Response, painter: Painter, projector: &crate::Projector) {
+    fn draw(
+        &self,
+        _response: &Response,
+        _gesture_handled: bool,
+        painter: Painter,
+        projector: &crate::Projector,
+    ) {
         let screen_position = projector.project(self.position);
 
         let label = painter.layout_no_wrap(
@@ -98,9 +104,15 @@ impl Places {
 }
 
 impl Plugin for Places {
-    fn draw(&self, response: &Response, painter: Painter, projector: &crate::Projector) {
+    fn draw(
+        &self,
+        response: &Response,
+        gesture_handled: bool,
+        painter: Painter,
+        projector: &crate::Projector,
+    ) {
         for place in &self.places {
-            place.draw(response, painter.clone(), projector);
+            place.draw(response, gesture_handled, painter.clone(), projector);
         }
     }
 }


### PR DESCRIPTION
Now map can held if it needed. It may suitable if need to display special information and prevent accidental scrolling or zooming of the map.

`gesture_handled` variable in plugins API is suitable for plugins that are needed to filter a garbage drag event, for example, after a "zoom" gesture. The 'dragged_by' event is triggered even if the zoom happened, but the fingers were not detached from the touch screen. Now plugins can known if gesture beggining at map's context.