### PR TITLE
move map::AdjustedPosition to public

### DIFF
--- a/walkers/src/lib.rs
+++ b/walkers/src/lib.rs
@@ -11,7 +11,7 @@ mod tiles;
 mod zoom;
 
 pub use download::HttpOptions;
-pub use map::{Map, MapMemory, Plugin, Projector};
+pub use map::{AdjustedPosition, Map, MapMemory, Plugin, Projector};
 pub use mercator::{screen_to_position, Position, TileId};
 pub use tiles::{Texture, Tiles, TilesManager};
 pub use zoom::InvalidZoom;

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -228,20 +228,27 @@ pub struct AdjustedPosition {
 }
 
 impl AdjustedPosition {
+    pub fn new(position: Position, offset: Vec2) -> Self {
+        Self {
+            position,
+            offset: Pixels::new(offset.x as f64, offset.y as f64),
+        }
+    }
+
     /// Calculate the real position, i.e. including the offset.
-    fn position(&self, zoom: u8) -> Position {
+    pub fn position(&self, zoom: u8) -> Position {
         screen_to_position(self.position.project(zoom) - self.offset, zoom)
     }
 
     /// Recalculate `position` so that `offset` is zero.
-    fn zero_offset(self, zoom: u8) -> Self {
+    pub fn zero_offset(self, zoom: u8) -> Self {
         Self {
             position: screen_to_position(self.position.project(zoom) - self.offset, zoom),
             offset: Default::default(),
         }
     }
 
-    fn shift(self, offset: Vec2) -> Self {
+    pub fn shift(self, offset: Vec2) -> Self {
         Self {
             position: self.position,
             offset: self.offset + Pixels::new(offset.x as f64, offset.y as f64),


### PR DESCRIPTION
It is a convenient way to get clicked coordinates on map