### PR TITLE
Smooth (decimal) zoom levels with gestures and scrolling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ Cargo.lock
 
 # Path where `demo_native` stores the HTTP cache.
 .cache
+
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
  * Plugins: Fixed problem of handle clicks after update to egui 0.26
+ * Map can be zoomed to decimal zoom levels with gestures or scrolling.
 
 ## 0.19.0
 

--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -10,7 +10,7 @@ use crate::io::Runtime;
 use crate::mercator::TileId;
 use crate::sources::{Attribution, TileSource};
 
-pub(crate) fn rect(screen_position: Vec2, tile_size: u32) -> Rect {
+pub(crate) fn rect(screen_position: Vec2, tile_size: f64) -> Rect {
     Rect::from_min_size(screen_position.to_pos2(), Vec2::splat(tile_size as f32))
 }
 
@@ -38,7 +38,7 @@ impl Texture {
         self.0.size_vec2()
     }
 
-    pub(crate) fn mesh(&self, screen_position: Vec2, tile_size: u32) -> Mesh {
+    pub(crate) fn mesh(&self, screen_position: Vec2, tile_size: f64) -> Mesh {
         self.mesh_with_rect(rect(screen_position, tile_size))
     }
 

--- a/walkers/src/zoom.rs
+++ b/walkers/src/zoom.rs
@@ -19,6 +19,14 @@ impl TryFrom<f32> for Zoom {
     }
 }
 
+// The reverse shouldn't be implemented, since we already have TryInto<f32>.
+#[allow(clippy::from_over_into)]
+impl Into<f64> for Zoom {
+    fn into(self) -> f64 {
+        self.0 as f64
+    }
+}
+
 impl Default for Zoom {
     fn default() -> Self {
         Self(16.)


### PR DESCRIPTION
This PR enables smooth zoom levels (between integers), so the sudden zooming is gone if users enable gestures and/or scroll-zooming.

It uses tiles from the nearest integer zoom level, and scales the tiles to fit decimal zoom levels. Calculations are done in `f64` precision, since `f32` precision causes rounding flaws under zoom levels 16+.

A lot of type changes (wherever `zoom` changes from `u8` to `f64`) happened, so I would expect an amount of breaking changes.

---

The tests are sure to compile, but has not yet been run. I anticipate some changes to the tests due to type issues.

The demo app has been tested on WASM and natively on macOS (M1). No issues observed.