### PR TITLE
build: remove default-features from image dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 version = "0.22.0"
 
 [workspace.dependencies]
-image = "0.25"
+image = { version = "0.25", default-features = false }
 log = "0.4"
 egui = "0.27"
 egui_extras = { version = "0.27", features = ["svg"] }

--- a/walkers/Cargo.toml
+++ b/walkers/Cargo.toml
@@ -14,7 +14,7 @@ log.workspace = true
 egui.workspace = true
 egui_extras.workspace = true
 thiserror = "1"
-image = { version = "0.25", features = ["jpeg", "png"] }
+image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 geo-types = { version = "0.7" }
 reqwest = { version = "0.11", default-features = false, features = [
     "rustls-tls",


### PR DESCRIPTION
Some of `image 0.25.1` dependencies requires rustc 1.79. With `default-features=false` these not used crates are omitted, allowing `walkers` to run on earlier rust versions. 

See details at https://github.com/rerun-io/rerun/pull/6561#issuecomment-2182134611 