### PR TITLE
Get and set exact zoom levels

### DIFF
--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -290,6 +290,18 @@ impl MapMemory {
         self.zoom.zoom_out()
     }
 
+    /// Set exact zoom level
+    pub fn set_zoom(&mut self, zoom: f32) -> Result<(), InvalidZoom> {
+        self.center_mode = self.center_mode.clone().zero_offset(self.zoom.into());
+        self.zoom = Zoom::try_from(zoom)?;
+        Ok(())
+    }
+
+    /// Returns the current zoom level
+    pub fn zoom(&self) -> f32 {
+        self.zoom.into()
+    }
+
     /// Returns exact position if map is detached (i.e. not following `my_position`),
     /// `None` otherwise.
     pub fn detached(&self) -> Option<Position> {

--- a/walkers/src/zoom.rs
+++ b/walkers/src/zoom.rs
@@ -27,6 +27,13 @@ impl Into<f64> for Zoom {
     }
 }
 
+#[allow(clippy::from_over_into)]
+impl Into<f32> for Zoom {
+    fn into(self) -> f32 {
+        self.0
+    }
+}
+
 impl Default for Zoom {
     fn default() -> Self {
         Self(16.)


### PR DESCRIPTION
As proposed in #163, I've added a new function for getting the zoom level as `fn zoom(&self) -> f32`. I also added a setter function to support slider on the UI.
