### PR TITLE
Update egui to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.24.0"
 [workspace.dependencies]
 image = { version = "0.25", default-features = false }
 log = "0.4"
-egui = "0.28"
-egui_extras = { version = "0.28", features = ["svg"] }
-eframe = "0.28"
-egui-winit = "0.28"
+egui = "0.29.1"
+egui_extras = { version = "0.29.1", features = ["svg"] }
+eframe = "0.29.1"
+egui-winit = "0.29.1"

--- a/demo_web/Cargo.toml
+++ b/demo_web/Cargo.toml
@@ -10,3 +10,4 @@ eframe.workspace = true
 egui.workspace = true
 log.workspace = true
 wasm-bindgen-futures = "0.4"
+web-sys = "0.3.70"

--- a/demo_web/src/main.rs
+++ b/demo_web/src/main.rs
@@ -1,4 +1,7 @@
 #[cfg(target_arch = "wasm32")]
+use eframe::wasm_bindgen::JsCast;
+
+#[cfg(target_arch = "wasm32")]
 fn main() {
     // Redirect `log` message to `console.log` and friends:
     eframe::WebLogger::init(log::LevelFilter::Debug).ok();
@@ -6,9 +9,20 @@ fn main() {
     let web_options = eframe::WebOptions::default();
 
     wasm_bindgen_futures::spawn_local(async {
+        let document = web_sys::window()
+            .expect("No window")
+            .document()
+            .expect("No document");
+
+        let canvas = document
+            .get_element_by_id("the_canvas_id")
+            .expect("Failed to find the_canvas_id")
+            .dyn_into::<web_sys::HtmlCanvasElement>()
+            .expect("the_canvas_id was not a HtmlCanvasElement");
+
         eframe::WebRunner::new()
             .start(
-                "the_canvas_id", // hardcode it
+                canvas,
                 web_options,
                 Box::new(|cc| Ok(Box::new(demo::MyApp::new(cc.egui_ctx.clone())))),
             )


### PR DESCRIPTION
Update `egui` to 0.29.

The migration for `WebRunner` is copied from the [official template](https://github.com/emilk/eframe_template/blob/main/src/main.rs#L38).

I wasn't sure if I should also bump the version of `walkers` or if you want to make some more changes before you release another version :)