### PR TITLE
Pass an owned value and an `egui::Ui` to `Plugin::run()`

### DIFF
--- a/demo/src/plugins.rs
+++ b/demo/src/plugins.rs
@@ -1,4 +1,4 @@
-use egui::{Color32, Painter, Response};
+use egui::{Color32, Response, Ui};
 use walkers::{
     extras::{Image, Images, Place, Places, Style, Texture},
     Plugin, Position, Projector,
@@ -57,7 +57,7 @@ pub fn images(images_plugin_data: &mut ImagesPluginData) -> impl Plugin {
 pub struct CustomShapes {}
 
 impl Plugin for CustomShapes {
-    fn run(&mut self, response: &Response, painter: Painter, projector: &Projector) {
+    fn run(self: Box<Self>, ui: &mut Ui, response: &Response, projector: &Projector) {
         // Position of the point we want to put our shapes.
         let position = places::capitol();
 
@@ -66,12 +66,13 @@ impl Plugin for CustomShapes {
 
         let radius = 30.;
 
+
         let hovered = response
             .hover_pos()
             .map(|hover_pos| hover_pos.distance(position) < radius)
             .unwrap_or(false);
 
-        painter.circle_filled(
+        ui.painter().circle_filled(
             position,
             radius,
             Color32::BLACK.gamma_multiply(if hovered { 0.5 } else { 0.2 }),
@@ -101,7 +102,7 @@ impl ClickWatcher {
 }
 
 impl Plugin for &mut ClickWatcher {
-    fn run(&mut self, response: &Response, painter: Painter, projector: &Projector) {
+    fn run(self: Box<Self>, ui: &mut Ui, response: &Response, projector: &Projector) {
         if !response.changed() && response.clicked_by(egui::PointerButton::Primary) {
             self.clicked_at = response
                 .interact_pointer_pos()
@@ -109,7 +110,7 @@ impl Plugin for &mut ClickWatcher {
         }
 
         if let Some(position) = self.clicked_at {
-            painter.circle_filled(projector.project(position).to_pos2(), 5.0, Color32::BLUE);
+            ui.painter().circle_filled(projector.project(position).to_pos2(), 5.0, Color32::BLUE);
         }
     }
 }

--- a/demo/src/plugins.rs
+++ b/demo/src/plugins.rs
@@ -66,7 +66,6 @@ impl Plugin for CustomShapes {
 
         let radius = 30.;
 
-
         let hovered = response
             .hover_pos()
             .map(|hover_pos| hover_pos.distance(position) < radius)
@@ -110,7 +109,8 @@ impl Plugin for &mut ClickWatcher {
         }
 
         if let Some(position) = self.clicked_at {
-            ui.painter().circle_filled(projector.project(position).to_pos2(), 5.0, Color32::BLUE);
+            ui.painter()
+                .circle_filled(projector.project(position).to_pos2(), 5.0, Color32::BLUE);
         }
     }
 }

--- a/walkers/src/extras/images.rs
+++ b/walkers/src/extras/images.rs
@@ -1,7 +1,6 @@
-use crate::tiles::Texture;
-use crate::{Plugin, Position};
-use egui::epaint::emath::Rot2;
-use egui::{Painter, Rect, Response, Vec2};
+use egui::{Rect, Ui, Vec2, emath::Rot2, Response};
+
+use crate::{Plugin, Position, tiles::Texture};
 
 /// An image to be drawn on the map.
 pub struct Image {
@@ -34,7 +33,8 @@ impl Image {
         self.angle = Rot2::from_angle(angle);
     }
 
-    pub fn draw(&self, _response: &Response, painter: Painter, projector: &crate::Projector) {
+    pub fn draw(&self, ui: &Ui, projector: &crate::Projector) {
+        let painter = ui.painter();
         let rect = Rect::from_center_size(
             projector.project(self.position).to_pos2(),
             self.texture.size() * self.scale,
@@ -60,9 +60,9 @@ impl Images {
 }
 
 impl Plugin for Images {
-    fn run(&mut self, response: &Response, painter: Painter, projector: &crate::Projector) {
+    fn run(self: Box<Self>, ui: &mut Ui, _response: &Response, projector: &crate::Projector) {
         for image in &self.images {
-            image.draw(response, painter.clone(), projector);
+            image.draw(ui, projector);
         }
     }
 }

--- a/walkers/src/extras/images.rs
+++ b/walkers/src/extras/images.rs
@@ -1,6 +1,6 @@
-use egui::{Rect, Ui, Vec2, emath::Rot2, Response};
+use egui::{emath::Rot2, Rect, Response, Ui, Vec2};
 
-use crate::{Plugin, Position, tiles::Texture};
+use crate::{tiles::Texture, Plugin, Position};
 
 /// An image to be drawn on the map.
 pub struct Image {

--- a/walkers/src/extras/places.rs
+++ b/walkers/src/extras/places.rs
@@ -1,4 +1,4 @@
-use egui::{vec2, Align2, Color32, FontId, Ui, Stroke, Response};
+use egui::{vec2, Align2, Color32, FontId, Response, Stroke, Ui};
 
 use crate::{Plugin, Position};
 
@@ -68,11 +68,7 @@ impl Place {
             self.style.label_background,
         );
 
-        painter.galley(
-            (screen_position + offset).to_pos2(),
-            label,
-            Color32::BLACK,
-        );
+        painter.galley((screen_position + offset).to_pos2(), label, Color32::BLACK);
 
         painter.circle(
             screen_position.to_pos2(),

--- a/walkers/src/extras/places.rs
+++ b/walkers/src/extras/places.rs
@@ -1,4 +1,4 @@
-use egui::{vec2, Align2, Color32, FontId, Painter, Response, Stroke};
+use egui::{vec2, Align2, Color32, FontId, Ui, Stroke, Response};
 
 use crate::{Plugin, Position};
 
@@ -45,8 +45,9 @@ pub struct Place {
 }
 
 impl Place {
-    fn draw(&self, _response: &Response, painter: Painter, projector: &crate::Projector) {
+    fn draw(&self, ui: &Ui, projector: &crate::Projector) {
         let screen_position = projector.project(self.position);
+        let painter = ui.painter();
 
         let label = painter.layout_no_wrap(
             self.label.to_owned(),
@@ -70,7 +71,7 @@ impl Place {
         painter.galley(
             (screen_position + offset).to_pos2(),
             label,
-            egui::Color32::BLACK,
+            Color32::BLACK,
         );
 
         painter.circle(
@@ -102,9 +103,9 @@ impl Places {
 }
 
 impl Plugin for Places {
-    fn run(&mut self, response: &Response, painter: Painter, projector: &crate::Projector) {
+    fn run(self: Box<Self>, ui: &mut Ui, _response: &Response, projector: &crate::Projector) {
         for place in &self.places {
-            place.draw(response, painter.clone(), projector);
+            place.draw(ui, projector);
         }
     }
 }

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -15,10 +15,10 @@ use crate::{
 pub trait Plugin {
     /// Function called at each frame.
     ///
-    /// The provided [`Ui`] has its [`egui::Ui::max_rect`] set to the full rect that was allocated
+    /// The provided [`Ui`] has its [`Ui::max_rect`] set to the full rect that was allocated
     /// by the map widget. Implementations should typically use the provided [`Projector`] to
     /// compute target screen coordinates and use one of the various egui methods to draw at these
-    /// coordinates instead of relying on [`egui:Ui`] layout system.
+    /// coordinates instead of relying on [`Ui`] layout system.
     ///
     /// The provided [`Response`] is the response of the map widget itself and can be used to test
     /// if the mouse is hovering or clicking on the map.


### PR DESCRIPTION
This PR changes the API of `Plugin::run()` in two ways:

- It pass an owned value of `Plugin` instead of a mutable reference. Based on my experience for similar APIs (e.g. [Rerun's `list_item`](https://github.com/rerun-io/rerun/blob/1e38ae23290487bc3082f125da3ef8de29845175/crates/viewer/re_ui/src/list_item/mod.rs#L76)), it can be very useful for implementer to have an owned value. For example it makes it possible for the plugin to carry a `dyn FnOnce`. This works because plugins are only ever called once. The trick to keep the trait object safe is to force the value to be wrapped in a `Box`. That's how things are already, so I figured this is acceptable.
- It pass an `egui::Ui` instead of an `egui::Painter`. This enables using egui to create more complex interactions within the view, for example hover tooltips etc. (see https://github.com/podusowski/walkers/issues/197).

Fixes https://github.com/podusowski/walkers/issues/197