### PR TITLE
Change log level to `TRACE` for some tile-download-related messages

### DIFF
--- a/walkers/src/download.rs
+++ b/walkers/src/download.rs
@@ -67,7 +67,7 @@ async fn download_and_decode(
     user_agent: &HeaderValue,
     egui_ctx: &Context,
 ) -> Download {
-    log::debug!("Downloading '{}'.", url);
+    log::trace!("Downloading '{}'.", url);
     Download {
         tile_id,
         result: download_and_decode_impl(client, url, user_agent, egui_ctx).await,
@@ -87,7 +87,7 @@ async fn download_and_decode_impl(
         .await
         .map_err(Error::HttpMiddleware)?;
 
-    log::debug!("Downloaded '{}': {:?}.", url, image.status());
+    log::trace!("Downloaded '{}': {:?}.", url, image.status());
 
     let image = image
         .error_for_status()

--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -144,7 +144,7 @@ impl HttpTiles {
 
     fn request_download(&mut self, tile_id: TileId) {
         if let Ok(()) = self.request_tx.try_send(tile_id) {
-            log::debug!("Requested tile: {:?}", tile_id);
+            log::trace!("Requested tile: {:?}", tile_id);
 
             // None acts as a placeholder for the tile, preventing multiple
             // requests for the same tile.


### PR DESCRIPTION
Fixes #199 