### PR TITLE
Allow to zoom in farther than what is supported by the tile source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 * Fixed crash when zoom is maxed far out.
 * Add `Project::scale_pixel_per_meter()` to provide the local meter-to-pixel scale.
+* Map can be zoomed in farther than what is supported by the tile provider. The max. zoom level
+  for which tile images are available can be configured via `TileSource::max_zoom()`.
 
 ## 0.26.0
 

--- a/walkers/src/sources/mod.rs
+++ b/walkers/src/sources/mod.rs
@@ -26,4 +26,8 @@ pub trait TileSource {
     fn tile_size(&self) -> u32 {
         256
     }
+
+    fn max_zoom(&self) -> u8 {
+        19
+    }
 }

--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -85,6 +85,8 @@ pub struct HttpTiles {
     runtime: Runtime,
 
     tile_size: u32,
+
+    max_zoom: u8,
 }
 
 impl HttpTiles {
@@ -108,6 +110,7 @@ impl HttpTiles {
         let (tile_tx, tile_rx) = futures::channel::mpsc::channel(channel_size);
         let attribution = source.attribution();
         let tile_size = source.tile_size();
+        let max_zoom = source.max_zoom();
 
         let runtime = Runtime::new(download_continuously(
             source,
@@ -127,6 +130,7 @@ impl HttpTiles {
             tile_rx,
             runtime,
             tile_size,
+            max_zoom,
         }
     }
 

--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -149,16 +149,19 @@ impl HttpTiles {
         }
     }
 
-    fn request_download(&mut self, tile_id: TileId) {
-        if let Ok(()) = self.request_tx.try_send(tile_id) {
-            log::trace!("Requested tile: {:?}", tile_id);
+    fn request_tile(&mut self, tile_id: TileId) -> Option<Texture> {
+        self.cache.get(&tile_id).cloned().unwrap_or_else(|| {
+            if let Ok(()) = self.request_tx.try_send(tile_id) {
+                log::trace!("Requested tile: {:?}", tile_id);
 
-            // None acts as a placeholder for the tile, preventing multiple
-            // requests for the same tile.
-            self.cache.put(tile_id, None);
-        } else {
-            log::debug!("Request queue is full.");
-        }
+                // None acts as a placeholder for the tile, preventing multiple
+                // requests for the same tile.
+                self.cache.put(tile_id, None);
+            } else {
+                log::debug!("Request queue is full.");
+            }
+            None
+        })
     }
 
     /// Find tile with a different zoom, which could be used as a placeholder.
@@ -203,17 +206,12 @@ impl Tiles for HttpTiles {
         self.put_next_downloaded_tile_in_cache();
 
         if tile_id.zoom <= self.max_zoom {
-            if let Some(texture) = self.cache.get(&tile_id).cloned() {
-                texture
-            } else {
-                self.request_download(tile_id);
-                None
-            }
-            .map(|texture| TextureWithUv {
-                texture,
-                uv: Rect::from_min_max(pos2(0.0, 0.0), pos2(1.0, 1.0)),
-            })
-            .or_else(|| self.placeholder_with_different_zoom(tile_id))
+            self.request_tile(tile_id)
+                .map(|texture| TextureWithUv {
+                    texture,
+                    uv: Rect::from_min_max(pos2(0.0, 0.0), pos2(1.0, 1.0)),
+                })
+                .or_else(|| self.placeholder_with_different_zoom(tile_id))
         } else {
             let dzoom = 2u32.pow((tile_id.zoom - self.max_zoom) as u32);
             let x = (tile_id.x / dzoom, tile_id.x % dzoom);
@@ -225,21 +223,18 @@ impl Tiles for HttpTiles {
                 zoom: self.max_zoom,
             };
 
-            if let Some(Some(texture)) = self.cache.get(&zoomed_tile_id) {
+            self.request_tile(zoomed_tile_id).map(|texture| {
                 let z = (dzoom as f32).recip();
                 let uv = Rect::from_min_max(
                     pos2(x.1 as f32 * z, y.1 as f32 * z),
                     pos2(x.1 as f32 * z + z, y.1 as f32 * z + z),
                 );
 
-                Some(TextureWithUv {
+                TextureWithUv {
                     texture: texture.clone(),
                     uv,
-                })
-            } else {
-                self.request_download(zoomed_tile_id);
-                None
-            }
+                }
+            })
         }
     }
 

--- a/walkers/src/zoom.rs
+++ b/walkers/src/zoom.rs
@@ -9,9 +9,8 @@ impl TryFrom<f64> for Zoom {
     type Error = InvalidZoom;
 
     fn try_from(value: f64) -> Result<Self, Self::Error> {
-        // Mapnik supports zooms up to 19.
-        // https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Zoom_levels
-        if !(0. ..=19.).contains(&value) {
+        // The upper limit is artificial. Should it be removed altogether?
+        if !(0. ..=26.).contains(&value) {
             Err(InvalidZoom)
         } else {
             Ok(Self(value))
@@ -63,15 +62,15 @@ mod tests {
     #[test]
     fn test_constructing_zoom() {
         assert_eq!(16, Zoom::default().round());
-        assert_eq!(19, Zoom::try_from(19.).unwrap().round());
-        assert_eq!(InvalidZoom, Zoom::try_from(20.).unwrap_err());
+        assert_eq!(26, Zoom::try_from(26.).unwrap().round());
+        assert_eq!(InvalidZoom, Zoom::try_from(27.).unwrap_err());
     }
 
     #[test]
     fn test_zooming_in() {
-        let mut zoom = Zoom::try_from(18.).unwrap();
+        let mut zoom = Zoom::try_from(25.).unwrap();
         assert!(zoom.zoom_in().is_ok());
-        assert_eq!(19, zoom.round());
+        assert_eq!(26, zoom.round());
         assert_eq!(Err(InvalidZoom), zoom.zoom_in());
     }
 


### PR DESCRIPTION
Fixes #110. I did not check the original solution attempt.

 * [x] Map is displaying and reacting to input correctly, both natively and on the web.
   only tested natively
 * [X] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
