### PR TITLE
Do not set a user agent in wasm builds by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* Do not set a user agent in wasm build by default.
+
 ## 0.28.0
 
 * Implement panning with touchpad and/or scroll-wheel.

--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -338,7 +338,7 @@ mod tests {
             source,
             HttpOptions {
                 cache: None,
-                user_agent: crate::HeaderValue::from_static("MyApp"),
+                user_agent: Some(crate::HeaderValue::from_static("MyApp")),
             },
             Context::default(),
         );


### PR DESCRIPTION
This PR makes setting the user agent optional, and default to not set one on wasm build. On the web, the user agent should be set by the browser (map provider can filter on `Origin` instead). Trying to override the user agent upsets _some_ servers (e.g. Mapbox) on some browsers (e.g. Safari and Firefox, but not Chrome).

This PR has been tested [here](https://github.com/rerun-io/rerun/pull/8022) and show to produce the expected result.

 * [x] Map is displaying and reacting to input correctly, both natively and on the web.
 * [x] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
