### PR TITLE
extend download::Error with termination events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* Fixed spurious "Error from IO runtime" at shutdown.
+
 ## 0.29.0
 
 * Do not set a user agent in wasm build by default.

--- a/walkers/src/download.rs
+++ b/walkers/src/download.rs
@@ -136,10 +136,7 @@ async fn download_complete(
 ) -> Result<(), Error> {
     match result {
         Ok(tile) => {
-            tile_tx
-                .send((tile_id, tile))
-                .await
-                .map_err(|error| Error::from(error))?;
+            tile_tx.send((tile_id, tile)).await.map_err(Error::from)?;
             egui_ctx.request_repaint();
         }
         Err(e) => {

--- a/walkers/src/download.rs
+++ b/walkers/src/download.rs
@@ -61,6 +61,25 @@ enum Error {
 
     #[error(transparent)]
     Image(ImageError),
+
+    #[error("Tile request channel from the main thread was broken.")]
+    RequestChannelBroken,
+
+    #[error("Tile channel to the main thread was broken.")]
+    TileChannelClosed,
+
+    #[error("Tile channel to the main thread was full.")]
+    TileChannelFull,
+}
+
+impl From<futures::channel::mpsc::SendError> for Error {
+    fn from(error: futures::channel::mpsc::SendError) -> Self {
+        if error.is_disconnected() {
+            Error::TileChannelClosed
+        } else {
+            Error::TileChannelFull
+        }
+    }
 }
 
 struct Download {
@@ -114,13 +133,18 @@ async fn download_complete(
     egui_ctx: Context,
     tile_id: TileId,
     result: Result<Texture, Error>,
-) -> Result<(), ()> {
+) -> Result<(), Error> {
     match result {
         Ok(tile) => {
-            tile_tx.send((tile_id, tile)).await.map_err(|_| ())?;
+            tile_tx
+                .send((tile_id, tile))
+                .await
+                .map_err(|error| Error::from(error))?;
             egui_ctx.request_repaint();
         }
         Err(e) => {
+            // It would probably be more consistent to push it to the caller, but it's not that
+            // important right now.
             log::warn!("{}", e);
         }
     };
@@ -156,7 +180,7 @@ async fn download_continuously_impl<S>(
     mut request_rx: futures::channel::mpsc::Receiver<TileId>,
     tile_tx: futures::channel::mpsc::Sender<(TileId, Texture)>,
     egui_ctx: Context,
-) -> Result<(), ()>
+) -> Result<(), Error>
 where
     S: TileSource + Send + 'static,
 {
@@ -169,7 +193,7 @@ where
     loop {
         downloads = match downloads {
             Downloads::None => {
-                let request = request_rx.next().await.ok_or(())?;
+                let request = request_rx.next().await.ok_or(Error::RequestChannelBroken)?;
                 let url = source.tile_url(request);
                 let download =
                     download_and_decode(&client, request, url, user_agent.as_ref(), &egui_ctx);
@@ -180,7 +204,7 @@ where
                 match select(request_rx.next(), download).await {
                     // New download was requested.
                     Either::Left((request, downloads)) => {
-                        let request = request.ok_or(())?;
+                        let request = request.ok_or(Error::RequestChannelBroken)?;
                         let url = source.tile_url(request);
                         let download = download_and_decode(
                             &client,
@@ -231,10 +255,12 @@ pub(crate) async fn download_continuously<S>(
 ) where
     S: TileSource + Send + 'static,
 {
-    if download_continuously_impl(source, http_options, request_rx, tile_tx, egui_ctx)
-        .await
-        .is_err()
-    {
-        log::error!("Error from IO runtime.");
+    match download_continuously_impl(source, http_options, request_rx, tile_tx, egui_ctx).await {
+        Ok(()) | Err(Error::TileChannelClosed) | Err(Error::RequestChannelBroken) => {
+            log::debug!("Tile download loop finished.");
+        }
+        Err(error) => {
+            log::error!("Tile download loop failed: {}.", error);
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/podusowski/walkers/issues/224

 * [x] Map is displaying and reacting to input correctly, both natively and on the web.
 * [x] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
