### PR TITLE
Fix zoom not following cursor if the map wasnt moved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* Fix zoom not following cursor if the map wasn't moved
+
 ## 0.29.0
 
 * Do not set a user agent in wasm build by default.

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -167,17 +167,21 @@ impl Map<'_, '_, '_> {
             // Displacement of mouse pointer relative to widget center
             let offset = response.hover_pos().map(|p| p - response.rect.center());
 
+            let pos = self
+                .memory
+                .center_mode
+                .position(self.my_position, self.memory.zoom());
+
             // While zooming, we want to keep the location under the mouse pointer fixed on the
             // screen. To achieve this, we first move the location to the widget's center,
             // then adjust zoom level, finally move the location back to the original screen
             // position.
             if let Some(offset) = offset {
-                self.memory.center_mode = self
-                    .memory
-                    .center_mode
-                    .clone()
-                    .shift(-offset)
-                    .zero_offset(self.memory.zoom.into());
+                self.memory.center_mode = Center::Exact(
+                    AdjustedPosition::from(pos)
+                        .shift(-offset)
+                        .zero_offset(self.memory.zoom.into()),
+                );
             }
 
             // Shift by 1 because of the values given by zoom_delta(). Multiple by 2, because


### PR DESCRIPTION
I have a couple of changes that I have made locally for a project that I thought I would upstream if it has interest, I split them up into seperate PR's, if some of the things aren't a fit for the main crate 

Let me know if you would prefer it to be one big PR instead

There was an issue where the zoom wouldn't follow the cursor if the state of the center was still `MyPosition` as it is initially. This would cause the shift operation to not do anything, thus the zoom didn't shift the map, and just zoomed out in the center of the screen even if the cursor was somewhere else 
![wrong_initial_zoom](https://github.com/user-attachments/assets/bad4dc30-ee21-4990-a137-435f0d9854b1)

After the change we now correctly zoom, before we have panned the map

![fix_wrong_initial_zoom](https://github.com/user-attachments/assets/65d32ed4-4785-4664-946c-d0a0fd9c1349)


* [x] Map is displaying and reacting to input correctly, both natively and on the web.
* [x] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
