### PR TITLE
Allow zooming without ctrl key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* Add option to zoom without holding ctrl on native and web
+
 ## 0.29.0
 
 * Do not set a user agent in wasm build by default.

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -173,7 +173,7 @@ impl Map<'_, '_, '_> {
         let mut zoom_delta = ui.input(|input| input.zoom_delta()) as f64;
 
         if !self.zoom_with_ctrl && zoom_delta == 1.0 {
-            // We only use the raw scroll values, if we are zooming without ctrl, 
+            // We only use the raw scroll values, if we are zooming without ctrl,
             // and zoom_delta is not already over/under 1.0 (eg. a ctrl + scroll event or a pinch zoom)
             // These values seem to corrospond to the same values as one would get in `zoom_delta()`
             zoom_delta = ui.input(|input| (1.0 + input.smooth_scroll_delta.y / 200.0)) as f64


### PR DESCRIPTION
A lot of map type applications like google maps, and open street maps allows for just zooming with the scroll wheel without ctrl. I wanted to have this option in my own project. 

This is by default disabled in this PR. And if enabled it should only affect native/web. Multi-touch should retain it's normal functionality

 * [X] Map is displaying and reacting to input correctly, both natively and on the web.
 * [X] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
