### PR TITLE
Add option for changing the zoom speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* Add option for changing the zoom speed
+
 ## 0.29.0
 
 * Do not set a user agent in wasm build by default.

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -49,6 +49,7 @@ pub struct Map<'a, 'b, 'c> {
 
     zoom_gesture_enabled: bool,
     drag_gesture_enabled: bool,
+    zoom_speed: f64,
 }
 
 impl<'a, 'b, 'c> Map<'a, 'b, 'c> {
@@ -64,6 +65,7 @@ impl<'a, 'b, 'c> Map<'a, 'b, 'c> {
             plugins: Vec::default(),
             zoom_gesture_enabled: true,
             drag_gesture_enabled: true,
+            zoom_speed: 1.0,
         }
     }
 
@@ -85,6 +87,12 @@ impl<'a, 'b, 'c> Map<'a, 'b, 'c> {
     /// Set whether map should perform drag gesture.
     pub fn drag_gesture(mut self, enabled: bool) -> Self {
         self.drag_gesture_enabled = enabled;
+        self
+    }
+
+    /// Change how far to zoom in/out
+    pub fn zoom_speed(mut self, speed: f64) -> Self {
+        self.zoom_speed = speed;
         self
     }
 }
@@ -182,7 +190,9 @@ impl Map<'_, '_, '_> {
 
             // Shift by 1 because of the values given by zoom_delta(). Multiple by 2, because
             // then it felt right with both mouse wheel, and an Android phone.
-            self.memory.zoom.zoom_by((zoom_delta - 1.) * 2.);
+            self.memory
+                .zoom
+                .zoom_by((zoom_delta - 1.) * 2. * self.zoom_speed);
 
             // Recalculate the AdjustedPosition's offset, since it gets invalidated by zooming.
             self.memory.center_mode = self

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -100,8 +100,9 @@ impl<'a, 'b, 'c> Map<'a, 'b, 'c> {
     /// Default value is 2.0
     pub fn zoom_speed(mut self, speed: f64) -> Self {
         self.zoom_speed = speed;
+        self
     }
-  
+
     /// Set whether to enable double click primary mouse button to zoom
     pub fn double_click_to_zoom(mut self, enabled: bool) -> Self {
         self.double_click_to_zoom = enabled;


### PR DESCRIPTION
I found that the default zoom speed, wasn't quite what I wanted, so I added an option for changing it 

Default speed:

![zoom_1x](https://github.com/user-attachments/assets/f5e12dd8-9034-4acd-b233-f1f9dfc857c2)

2x speed:

![zoom_2x](https://github.com/user-attachments/assets/a3620940-23c0-4426-b5e6-4ceeff65f7e3)

0.5x speed:

![zoom_0_5x](https://github.com/user-attachments/assets/20be7070-837d-4a1d-9e96-44c009e150f9)


* [X] Map is displaying and reacting to input correctly, both natively and on the web.
 * [X] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
