### PR TITLE
Add options for double click zoom in and zoom out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* Add options for double click to zoom in and out
+
 ## 0.29.0
 
 * Do not set a user agent in wasm build by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ All notable changes to this project will be documented in this file.
 * Fixed zoom not following cursor if the map wasn't moved.
 * Fixed spurious "Error from IO runtime" at shutdown.
 
-
 ## 0.29.0
 
 * Do not set a user agent in wasm build by default.


### PR DESCRIPTION
Most map applications allows for zooming in with a double-click of the primary button. And some also allows for zooming out again with a double click of the secondary button.

![double_click_zoom](https://github.com/user-attachments/assets/e26639e9-12fb-42f1-8ae0-eb3a0ceb362d)


* [X] Map is displaying and reacting to input correctly, both natively and on the web.
 * [X] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
