### PR TITLE
fix Cargo warning

### DIFF
--- a/demo_android/rust/Cargo.toml
+++ b/demo_android/rust/Cargo.toml
@@ -16,4 +16,4 @@ thiserror = "2.0.3"
 
 [lib]
 name = "main"
-crate_type = ["cdylib"]
+crate-type = ["cdylib"]


### PR DESCRIPTION
 * [x] Map is displaying and reacting to input correctly, both natively and on the web.
 * [x] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
