### PR TITLE
Minor download cleanup

### DIFF
--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -121,12 +121,13 @@ impl HttpTiles {
             egui_ctx,
         ));
 
+        // Just arbitrary value which seemed right.
         #[allow(clippy::unwrap_used)]
-        let cap = std::num::NonZeroUsize::new(256).unwrap();
+        let cache_size = std::num::NonZeroUsize::new(256).unwrap();
 
         Self {
             attribution,
-            cache: LruCache::new(cap), // Just arbitrary value which seemed right.
+            cache: LruCache::new(cache_size),
             request_tx,
             tile_rx,
             runtime,


### PR DESCRIPTION
 * [x] Map is displaying and reacting to input correctly, both natively and on the web.
 * [x] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
