### PR TITLE
Simplify download code.

### DIFF
--- a/walkers/src/download.rs
+++ b/walkers/src/download.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, pin::Pin};
+use std::path::PathBuf;
 
 use egui::Context;
 use futures::{
@@ -151,27 +151,9 @@ async fn download_complete(
     Ok(())
 }
 
-enum Downloads<F> {
-    None,
-    Ongoing(Vec<Pin<Box<F>>>),
-    OngoingSaturated(Vec<Pin<Box<F>>>),
-}
-
 /// Maximum number of parallel downloads. Following modern browsers' behavior.
 /// https://stackoverflow.com/questions/985431/max-parallel-http-connections-in-a-browser
 const MAX_PARALLEL_DOWNLOADS: usize = 6;
-
-impl<F> Downloads<F> {
-    fn new(downloads: Vec<Pin<Box<F>>>) -> Self {
-        if downloads.is_empty() {
-            Self::None
-        } else if downloads.len() < MAX_PARALLEL_DOWNLOADS {
-            Self::Ongoing(downloads)
-        } else {
-            Self::OngoingSaturated(downloads)
-        }
-    }
-}
 
 async fn download_continuously_impl<S>(
     source: S,

--- a/walkers/src/download.rs
+++ b/walkers/src/download.rs
@@ -194,7 +194,7 @@ where
                 let url = source.tile_url(request);
                 let download =
                     download_and_decode(&client, request, url, user_agent.as_ref(), &egui_ctx);
-                Downloads::Ongoing(vec![Box::pin(download)])
+                Downloads::new(vec![Box::pin(download)])
             }
             Downloads::Ongoing(ref mut downloads) => {
                 let download = select_all(downloads.drain(..));


### PR DESCRIPTION
 * [ ] Map is displaying and reacting to input correctly, both natively and on the web.
 * [ ] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
