### PR TITLE
use MAX_PARALLEL_DOWNLOADS as channel size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* Tile download optimized by no longer queueing older requests.
+
 ## 0.30.0
 
 * Add option for changing the zoom speed

--- a/walkers/src/download.rs
+++ b/walkers/src/download.rs
@@ -157,7 +157,7 @@ enum Downloads<F> {
 
 /// Maximum number of parallel downloads. Following modern browsers' behavior.
 /// https://stackoverflow.com/questions/985431/max-parallel-http-connections-in-a-browser
-const MAX_PARALLEL_DOWNLOADS: usize = 6;
+pub(crate) const MAX_PARALLEL_DOWNLOADS: usize = 6;
 
 impl<F> Downloads<F> {
     fn new(downloads: Vec<Pin<Box<F>>>) -> Self {

--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -4,7 +4,7 @@ use futures::channel::mpsc::{channel, Receiver, Sender};
 use image::ImageError;
 use lru::LruCache;
 
-use crate::download::{download_continuously, HttpOptions};
+use crate::download::{download_continuously, HttpOptions, MAX_PARALLEL_DOWNLOADS};
 use crate::io::Runtime;
 use crate::mercator::TileId;
 use crate::sources::{Attribution, TileSource};
@@ -104,8 +104,8 @@ impl HttpTiles {
     where
         S: TileSource + Send + 'static,
     {
-        // Minimum value which didn't cause any stalls while testing.
-        let channel_size = 20;
+        // This ensures that newer requests are prioritized.
+        let channel_size = MAX_PARALLEL_DOWNLOADS;
 
         let (request_tx, request_rx) = channel(channel_size);
         let (tile_tx, tile_rx) = channel(channel_size);


### PR DESCRIPTION
Closes https://github.com/podusowski/walkers/issues/218

 * [x] Map is displaying and reacting to input correctly, both natively and on the web.
 * [x] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
