### PR TITLE
Update egui to 0.30.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.30.0"
 [workspace.dependencies]
 image = { version = "0.25", default-features = false }
 log = "0.4"
-egui = "0.29.1"
-egui_extras = { version = "0.29.1", features = ["svg"] }
-eframe = "0.29.1"
-egui-winit = "0.29.1"
+egui = "0.30.0"
+egui_extras = { version = "0.30.0", features = ["svg"] }
+eframe = "0.30.0"
+egui-winit = "0.30.0"


### PR DESCRIPTION
Supersedes:
- #238

Update egui to 0.30.0

 * [x] Map is displaying and reacting to input correctly, both natively and on the web.
 * [x] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
