### PR TITLE
Do not try to download tiles with invalid coords.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* Do not try to download tiles with invalid coordinates.
+
 ## 0.32.0
 
 * `egui` updated to 0.30.0.

--- a/walkers/src/mercator.rs
+++ b/walkers/src/mercator.rs
@@ -63,6 +63,10 @@ pub(crate) fn total_pixels(zoom: f64) -> f64 {
     2f64.powf(zoom) * (TILE_SIZE as f64)
 }
 
+pub fn total_tiles(zoom: u8) -> u32 {
+    2u32.pow(zoom as u32)
+}
+
 /// Size of a single tile in pixels. Walkers uses 256px tiles as most of the tile sources do.
 const TILE_SIZE: u32 = 256;
 
@@ -127,6 +131,10 @@ impl TileId {
     }
 
     pub fn east(&self) -> Option<TileId> {
+        if self.x == total_tiles(self.zoom) - 1 {
+            return None;
+        }
+
         Some(TileId {
             x: self.x + 1,
             y: self.y,
@@ -151,6 +159,10 @@ impl TileId {
     }
 
     pub fn south(&self) -> Option<TileId> {
+        if self.y == total_tiles(self.zoom) - 1 {
+            return None;
+        }
+
         Some(TileId {
             x: self.x,
             y: self.y + 1,
@@ -251,10 +263,10 @@ mod tests {
             zoom: 0,
         };
 
-        assert!(tile_id.west().is_none());
-        assert!(tile_id.north().is_none());
-        assert!(tile_id.south().is_some());
-        assert!(tile_id.east().is_some());
+        assert_eq!(tile_id.west(), None);
+        assert_eq!(tile_id.north(), None);
+        assert_eq!(tile_id.south(), None);
+        assert_eq!(tile_id.east(), None);
 
         // There are 2 tiles at zoom 1.
         let tile_id = TileId {
@@ -263,14 +275,8 @@ mod tests {
             zoom: 1,
         };
 
-        assert_eq!(
-            tile_id.west(),
-            Some(TileId {
-                x: 1,
-                y: 0,
-                zoom: 1
-            })
-        );
+        assert_eq!(tile_id.west(), None);
+        assert_eq!(tile_id.north(), None);
 
         assert_eq!(
             tile_id.south(),
@@ -281,7 +287,13 @@ mod tests {
             })
         );
 
-        assert!(tile_id.east().is_none());
-        assert!(tile_id.north().is_none());
+        assert_eq!(
+            tile_id.east(),
+            Some(TileId {
+                x: 1,
+                y: 0,
+                zoom: 1
+            })
+        );
     }
 }

--- a/walkers/src/mercator.rs
+++ b/walkers/src/mercator.rs
@@ -245,15 +245,43 @@ mod tests {
     #[test]
     fn tile_id_cannot_go_beyond_limits() {
         // There is only one tile at zoom 0.
-        assert!(TileId { x: 0, y: 0, zoom: 0 }.west().is_none());
-        assert!(TileId { x: 0, y: 0, zoom: 0 }.north().is_none());
-        assert!(TileId { x: 0, y: 0, zoom: 0 }.south().is_some());
-        assert!(TileId { x: 0, y: 0, zoom: 0 }.east().is_some());
+        let tile_id = TileId {
+            x: 0,
+            y: 0,
+            zoom: 0,
+        };
+
+        assert!(tile_id.west().is_none());
+        assert!(tile_id.north().is_none());
+        assert!(tile_id.south().is_some());
+        assert!(tile_id.east().is_some());
 
         // There are 2 tiles at zoom 1.
-        assert_eq!(TileId { x: 0, y: 0, zoom: 1 }.west(), Some(TileId { x: 1, y: 0, zoom: 1 }));
-        assert!(TileId { x: 0, y: 0, zoom: 1 }.north().is_none());
-        assert_eq!(TileId { x: 0, y: 0, zoom: 1 }.south(), Some(TileId { x: 0, y: 1, zoom: 1 }));
-        assert!(TileId { x: 0, y: 0, zoom: 1 }.east().is_none());
+        let tile_id = TileId {
+            x: 0,
+            y: 0,
+            zoom: 1,
+        };
+
+        assert_eq!(
+            tile_id.west(),
+            Some(TileId {
+                x: 1,
+                y: 0,
+                zoom: 1
+            })
+        );
+
+        assert_eq!(
+            tile_id.south(),
+            Some(TileId {
+                x: 0,
+                y: 1,
+                zoom: 1
+            })
+        );
+
+        assert!(tile_id.east().is_none());
+        assert!(tile_id.north().is_none());
     }
 }

--- a/walkers/src/mercator.rs
+++ b/walkers/src/mercator.rs
@@ -241,4 +241,19 @@ mod tests {
         approx::assert_relative_eq!(original.lon(), brought_back.lon());
         approx::assert_relative_eq!(original.lat(), brought_back.lat());
     }
+
+    #[test]
+    fn tile_id_cannot_go_beyond_limits() {
+        // There is only one tile at zoom 0.
+        assert!(TileId { x: 0, y: 0, zoom: 0 }.west().is_none());
+        assert!(TileId { x: 0, y: 0, zoom: 0 }.north().is_none());
+        assert!(TileId { x: 0, y: 0, zoom: 0 }.south().is_some());
+        assert!(TileId { x: 0, y: 0, zoom: 0 }.east().is_some());
+
+        // There are 2 tiles at zoom 1.
+        assert_eq!(TileId { x: 0, y: 0, zoom: 1 }.west(), Some(TileId { x: 1, y: 0, zoom: 1 }));
+        assert!(TileId { x: 0, y: 0, zoom: 1 }.north().is_none());
+        assert_eq!(TileId { x: 0, y: 0, zoom: 1 }.south(), Some(TileId { x: 0, y: 1, zoom: 1 }));
+        assert!(TileId { x: 0, y: 0, zoom: 1 }.east().is_none());
+    }
 }

--- a/walkers/src/mercator.rs
+++ b/walkers/src/mercator.rs
@@ -131,11 +131,7 @@ impl TileId {
     }
 
     pub fn east(&self) -> Option<TileId> {
-        if self.x == total_tiles(self.zoom) - 1 {
-            return None;
-        }
-
-        Some(TileId {
+        (self.x < total_tiles(self.zoom) - 1).then_some(TileId {
             x: self.x + 1,
             y: self.y,
             zoom: self.zoom,
@@ -159,11 +155,7 @@ impl TileId {
     }
 
     pub fn south(&self) -> Option<TileId> {
-        if self.y == total_tiles(self.zoom) - 1 {
-            return None;
-        }
-
-        Some(TileId {
+        (self.y < total_tiles(self.zoom) - 1).then_some(TileId {
             x: self.x,
             y: self.y + 1,
             zoom: self.zoom,


### PR DESCRIPTION
 * [x] Map is displaying and reacting to input correctly, both natively and on the web.
 * [x] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
