### PR TITLE
bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## 0.35.0
 
 * Fixed zooming on touchscreens so that it follows the center of the touch points.
 * `Projector::unproject` is now symmetric to `Projector::project`. Previously its origin was the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 
 [[package]]
 name = "demo"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "eframe",
  "egui",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "demo_android"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "android_logger",
  "demo",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "demo_native"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "demo",
  "eframe",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "demo_web"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "demo",
  "eframe",
@@ -4322,7 +4322,7 @@ dependencies = [
 
 [[package]]
 name = "walkers"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "approx",
  "eframe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.34.0"
+version = "0.35.0"
 
 [workspace.dependencies]
 image = { version = "0.25", default-features = false }


### PR DESCRIPTION
 * [ ] Map is displaying and reacting to input correctly, both natively and on the web.
 * [ ] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
