### PR TITLE
Encapsulate projection in Projector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* `screen_to_position` is no longer a public function. Use `Projector::unproject` to obtain
+  geographical coordinates from screen coordinates relative to the map viewport.
+
 ## 0.35.0
 
 * Fixed zooming on touchscreens so that it follows the center of the touch points.

--- a/walkers/src/lib.rs
+++ b/walkers/src/lib.rs
@@ -14,7 +14,7 @@ mod zoom;
 
 pub use download::{HeaderValue, HttpOptions};
 pub use map::{Map, MapMemory, Plugin, Projector};
-pub use mercator::{screen_to_position, TileId};
+pub use mercator::TileId;
 pub use position::{lat_lon, lon_lat, Position};
 pub use tiles::{HttpTiles, Texture, TextureWithUv, Tiles};
 pub use zoom::InvalidZoom;

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -4,7 +4,7 @@ use egui::{Mesh, PointerButton, Rect, Response, Sense, Ui, UiBuilder, Vec2, Widg
 
 use crate::{
     center::Center,
-    mercator::{project, screen_to_position, tile_id, TileId},
+    mercator::{project, tile_id, unproject, TileId},
     position::{AdjustedPosition, Pixels, PixelsExt},
     tiles,
     zoom::{InvalidZoom, Zoom},
@@ -175,7 +175,7 @@ impl Projector {
         let projected =
             project(center, zoom).to_vec2() - position + self.clip_rect.center().to_vec2();
 
-        screen_to_position(Pixels::new(projected.x as f64, projected.y as f64), zoom)
+        unproject(Pixels::new(projected.x as f64, projected.y as f64), zoom)
     }
 
     /// What is the local scale of the map at the provided position and given the current zoom

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -173,7 +173,7 @@ impl Projector {
         let zoom: f64 = self.memory.zoom.into();
         let center = self.memory.center_mode.position(self.my_position, zoom);
         let projected =
-            project(center, zoom).to_vec2() - position + self.clip_rect.center().to_vec2();
+            project(center, zoom).to_vec2() + position - self.clip_rect.center().to_vec2();
 
         unproject(Pixels::new(projected.x as f64, projected.y as f64), zoom)
     }

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -6,7 +6,7 @@ use crate::{
     center::Center,
     mercator::{project, tile_id, TileId},
     position::{AdjustedPosition, Pixels, PixelsExt},
-    tiles,
+    screen_to_position, tiles,
     zoom::{InvalidZoom, Zoom},
     Position, Tiles,
 };
@@ -172,13 +172,10 @@ impl Projector {
     pub fn unproject(&self, position: Vec2) -> Position {
         let zoom: f64 = self.memory.zoom.into();
         let center = self.memory.center_mode.position(self.my_position, zoom);
+        let projected =
+            project(center, zoom).to_vec2() - position + self.clip_rect.center().to_vec2();
 
-        AdjustedPosition {
-            position: center,
-            offset: Default::default(),
-        }
-        .shift(-position + self.clip_rect.center().to_vec2())
-        .position(zoom)
+        screen_to_position(Pixels::new(projected.x as f64, projected.y as f64), zoom)
     }
 
     /// What is the local scale of the map at the provided position and given the current zoom

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -4,9 +4,9 @@ use egui::{Mesh, PointerButton, Rect, Response, Sense, Ui, UiBuilder, Vec2, Widg
 
 use crate::{
     center::Center,
-    mercator::{project, tile_id, TileId},
+    mercator::{project, screen_to_position, tile_id, TileId},
     position::{AdjustedPosition, Pixels, PixelsExt},
-    screen_to_position, tiles,
+    tiles,
     zoom::{InvalidZoom, Zoom},
     Position, Tiles,
 };

--- a/walkers/src/mercator.rs
+++ b/walkers/src/mercator.rs
@@ -117,7 +117,7 @@ pub(crate) fn project(position: Position, zoom: f64) -> Pixels {
 }
 
 /// Transforms screen pixels into a geographical position.
-pub fn screen_to_position(pixels: Pixels, zoom: f64) -> Position {
+pub(crate) fn screen_to_position(pixels: Pixels, zoom: f64) -> Position {
     let number_of_pixels: f64 = 2f64.powf(zoom) * (TILE_SIZE as f64);
 
     let lon = pixels.x();

--- a/walkers/src/mercator.rs
+++ b/walkers/src/mercator.rs
@@ -117,7 +117,7 @@ pub(crate) fn project(position: Position, zoom: f64) -> Pixels {
 }
 
 /// Transforms screen pixels into a geographical position.
-pub(crate) fn screen_to_position(pixels: Pixels, zoom: f64) -> Position {
+pub(crate) fn unproject(pixels: Pixels, zoom: f64) -> Position {
     let number_of_pixels: f64 = 2f64.powf(zoom) * (TILE_SIZE as f64);
 
     let lon = pixels.x();
@@ -183,7 +183,7 @@ mod tests {
     fn project_there_and_back() {
         let citadel = lat_lon(21.00027, 52.26470);
         let zoom = 16;
-        let calculated = screen_to_position(project(citadel, zoom as f64), zoom as f64);
+        let calculated = unproject(project(citadel, zoom as f64), zoom as f64);
 
         approx::assert_relative_eq!(calculated.x(), citadel.x(), max_relative = 1.0);
         approx::assert_relative_eq!(calculated.y(), citadel.y(), max_relative = 1.0);

--- a/walkers/src/mercator.rs
+++ b/walkers/src/mercator.rs
@@ -20,7 +20,7 @@ pub(crate) fn total_pixels(zoom: f64) -> f64 {
     2f64.powf(zoom) * (TILE_SIZE as f64)
 }
 
-pub fn total_tiles(zoom: u8) -> u32 {
+pub(crate) fn total_tiles(zoom: u8) -> u32 {
     2u32.pow(zoom as u32)
 }
 

--- a/walkers/src/position.rs
+++ b/walkers/src/position.rs
@@ -1,6 +1,6 @@
 //! Types and functions for working with positions.
 
-use crate::mercator::{project, screen_to_position};
+use crate::mercator::{project, unproject};
 use egui::Vec2;
 
 /// Geographical position with latitude and longitude.
@@ -36,7 +36,7 @@ impl AdjustedPosition {
 
     /// Calculate the real position, i.e. including the offset.
     pub(crate) fn position(&self, zoom: f64) -> Position {
-        screen_to_position(project(self.position, zoom) - self.offset, zoom)
+        unproject(project(self.position, zoom) - self.offset, zoom)
     }
 
     /// Recalculate `position` so that `offset` is zero.

--- a/walkers/src/position.rs
+++ b/walkers/src/position.rs
@@ -42,7 +42,7 @@ impl AdjustedPosition {
     /// Recalculate `position` so that `offset` is zero.
     pub(crate) fn zero_offset(self, zoom: f64) -> Self {
         Self {
-            position: screen_to_position(project(self.position, zoom) - self.offset, zoom),
+            position: self.position(zoom),
             offset: Default::default(),
         }
     }

--- a/walkers/src/position.rs
+++ b/walkers/src/position.rs
@@ -1,6 +1,6 @@
 //! Types and functions for working with positions.
 
-use crate::{mercator::project, screen_to_position};
+use crate::mercator::{project, screen_to_position};
 use egui::Vec2;
 
 /// Geographical position with latitude and longitude.


### PR DESCRIPTION
I'm not yet sure how will it ultimately look like, but I'm hoping that abstracting the whole projection math behind `Projection` might help with things like https://github.com/podusowski/walkers/issues/250 or supporting different projections in general.

 * [ ] Map is displaying and reacting to input correctly, both natively and on the web.
 * [ ] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
