### PR TITLE
feat: serde support for `MapMemory`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose
+    - name: Cargo Check All Features
+      run: cargo check --all-features
     - name: Install Trunk
       run: cargo install trunk
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.37.0
+* `MapMemory` and `HttpTiles` now implement `serde::Serialize` and `serde::Deserialize` when the `serde` feature is enabled
+
 ## 0.36.0
 
 * `screen_to_position` is no longer a public function. Use `Projector::unproject` to obtain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 0.37.0
-* `MapMemory` and `HttpTiles` now implement `serde::Serialize` and `serde::Deserialize` when the `serde` feature is enabled
+* `MapMemory` now implements `serde::Serialize` and `serde::Deserialize` when the `serde` feature is enabled
 
 ## 0.36.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## 0.37.0
-* `MapMemory` now implements `serde::Serialize` and `serde::Deserialize` when the `serde` feature is enabled
+## Unreleased
+
+* `MapMemory` now implements `serde::Serialize` and `serde::Deserialize` when the `serde` feature is
+  enabled.
 
 ## 0.36.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4402,6 +4402,7 @@ dependencies = [
  "lru",
  "reqwest",
  "reqwest-middleware",
+ "serde",
  "thiserror 2.0.12",
  "tokio",
  "wasm-bindgen-futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,10 @@ name = "accesskit"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3d3b8f9bae46a948369bc4a03e815d4ed6d616bd00de4051133a5019dc31c5a"
+dependencies = [
+ "enumn",
+ "serde",
+]
 
 [[package]]
 name = "accesskit_atspi_common"
@@ -134,6 +138,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.15",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy 0.7.35",
 ]
@@ -1033,6 +1038,7 @@ checksum = "bc4feb366740ded31a004a0e4452fbf84e80ef432ecf8314c485210229672fd1"
 dependencies = [
  "bytemuck",
  "emath",
+ "serde",
 ]
 
 [[package]]
@@ -1087,6 +1093,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "profiling",
+ "serde",
 ]
 
 [[package]]
@@ -1175,6 +1182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e4cadcff7a5353ba72b7fea76bf2122b5ebdbc68e8155aa56dfdea90083fe1b"
 dependencies = [
  "bytemuck",
+ "serde",
 ]
 
 [[package]]
@@ -1235,6 +1243,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1292,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot",
  "profiling",
+ "serde",
 ]
 
 [[package]]

--- a/walkers/Cargo.toml
+++ b/walkers/Cargo.toml
@@ -42,4 +42,4 @@ hypermocker = { path = "../hypermocker" }
 
 [features]
 default = []
-serde = ["dep:serde"]
+serde = ["dep:serde", "geo-types/serde"]

--- a/walkers/Cargo.toml
+++ b/walkers/Cargo.toml
@@ -42,4 +42,4 @@ hypermocker = { path = "../hypermocker" }
 
 [features]
 default = []
-serde = ["dep:serde", "geo-types/serde"]
+serde = ["dep:serde", "geo-types/serde", "egui/serde"]

--- a/walkers/Cargo.toml
+++ b/walkers/Cargo.toml
@@ -24,6 +24,7 @@ reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
 ] }
 futures = "0.3.28"
+serde = { version = "1", features = ["derive"], optional = true }
 reqwest-middleware = "0.4.1"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
@@ -38,3 +39,7 @@ eframe.workspace = true
 env_logger = "0.11"
 approx = "0.5"
 hypermocker = { path = "../hypermocker" }
+
+[features]
+default = []
+serde = ["dep:serde"]

--- a/walkers/src/center.rs
+++ b/walkers/src/center.rs
@@ -10,6 +10,7 @@ use crate::{
 /// it becomes "detached" and stays this way until [`MapMemory::center_mode`] is changed back to
 /// [`Center::MyPosition`].
 #[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub(crate) enum Center {
     /// Centered at `my_position` argument of the [`Map::new()`] function.
     #[default]

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -336,6 +336,7 @@ impl Widget for Map<'_, '_, '_> {
 
 /// State of the map widget which must persist between frames.
 #[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct MapMemory {
     center_mode: Center,
     zoom: Zoom,

--- a/walkers/src/position.rs
+++ b/walkers/src/position.rs
@@ -21,6 +21,7 @@ pub fn lon_lat(lon: f64, lat: f64) -> Position {
 /// [`Position`] alone is not able to represent detached (e.g. after map gets dragged) position
 /// due to insufficient accuracy.
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct AdjustedPosition {
     /// Base geographical position.
     pub position: Position,

--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -73,6 +73,7 @@ pub trait Tiles {
 }
 
 /// Downloads the tiles via HTTP. It must persist between frames.
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct HttpTiles {
     attribution: Attribution,
     cache: LruCache<TileId, Option<Texture>>,

--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -73,7 +73,6 @@ pub trait Tiles {
 }
 
 /// Downloads the tiles via HTTP. It must persist between frames.
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct HttpTiles {
     attribution: Attribution,
     cache: LruCache<TileId, Option<Texture>>,

--- a/walkers/src/zoom.rs
+++ b/walkers/src/zoom.rs
@@ -3,6 +3,7 @@
 pub struct InvalidZoom;
 
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub(crate) struct Zoom(f64);
 
 impl TryFrom<f64> for Zoom {


### PR DESCRIPTION
Tiny change to close #281. Adds conditionally-compiled derives of `Serialize` and `Deserialize` to `MapMemory` and relevant structs. This and `HttpTiles` seemed like the only two structs that needed this, as they're the only two structs that are expected to be persisted between frames. However, `HttpTiles` has a bunch of fields (notably the cache) in 3rdparties that don't implement the required traits, so I left it alone.

 * [x] Map is displaying and reacting to input correctly, both natively and on the web. (I didn't test Android, because I don't have an Android device, but this change shouldn't affect that anyway.)
 * [x] `CHANGELOG.md` was updated with relevant information (or the change was purely internal). I added a new 0.37.0 header, please edit it to whatever you think is needed