### PR TITLE
removed MAX_PARALLEL_DOWNLOADS and fixed channel size

### DIFF
--- a/walkers/src/download.rs
+++ b/walkers/src/download.rs
@@ -67,7 +67,7 @@ impl Default for HttpOptions {
 }
 
 /// Maximum number of parallel downloads.
-pub struct MaxParallelDownloads(usize);
+pub struct MaxParallelDownloads(pub usize);
 
 impl Default for MaxParallelDownloads {
     /// Default number of parallel downloads. Following modern browsers' behavior.
@@ -87,8 +87,6 @@ impl MaxParallelDownloads {
         Self(value)
     }
 }
-
-pub(crate) const MAX_PARALLEL_DOWNLOADS: usize = 6;
 
 #[derive(Debug, thiserror::Error)]
 enum Error {

--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -6,7 +6,7 @@ use futures::channel::mpsc::{channel, Receiver, Sender, TrySendError};
 use image::ImageError;
 use lru::LruCache;
 
-use crate::download::{download_continuously, HttpOptions, MAX_PARALLEL_DOWNLOADS};
+use crate::download::{download_continuously, HttpOptions};
 use crate::io::Runtime;
 use crate::mercator::TileId;
 use crate::sources::{Attribution, TileSource};
@@ -108,7 +108,7 @@ impl HttpTiles {
         let http_stats = Arc::new(Mutex::new(HttpStats { in_progress: 0 }));
 
         // This ensures that newer requests are prioritized.
-        let channel_size = MAX_PARALLEL_DOWNLOADS;
+        let channel_size = http_options.max_parallel_downloads.0;
 
         let (request_tx, request_rx) = channel(channel_size);
         let (tile_tx, tile_rx) = channel(channel_size);


### PR DESCRIPTION
 * [ ] Map is displaying and reacting to input correctly, both natively and on the web.
 * [ ] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
