### PR TITLE
[Improvement] Make inertial speed reduction exponential 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+* Make slow-down during inertial moves exponential rather than linear.
+
 ## 0.37.0
 
 * Support for multiple layers.

--- a/walkers/src/center.rs
+++ b/walkers/src/center.rs
@@ -96,7 +96,7 @@ impl Center {
                     Center::Inertia {
                         position: AdjustedPosition::new(position.position, offset),
                         direction: *direction,
-                        amount: *amount * lp_factor
+                        amount: *amount * lp_factor,
                     }
                 };
                 true

--- a/walkers/src/center.rs
+++ b/walkers/src/center.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 /// Time constant of inertia stopping filter
-const INTERTIA_TAU: f32 = 0.2f32;
+const INERTIA_TAU: f32 = 0.2f32;
 
 /// Position at the map's center. Initially, the map follows `my_position` argument which typically
 /// is meant to be fed by a GPS sensor or other geo-localization method. If user drags the map,
@@ -91,7 +91,7 @@ impl Center {
                     let offset = position.offset + Pixels::new(delta.x as f64, delta.y as f64);
 
                     // Exponentially drive the `amount` value towards zero
-                    let lp_factor = INTERTIA_TAU / (delta_time + INTERTIA_TAU);
+                    let lp_factor = INERTIA_TAU / (delta_time + INERTIA_TAU);
 
                     Center::Inertia {
                         position: AdjustedPosition::new(position.position, offset),

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -308,7 +308,8 @@ impl Widget for Map<'_, '_, '_> {
             ui.allocate_exact_size(ui.available_size(), Sense::click_and_drag());
 
         let mut moved = self.handle_gestures(ui, &response);
-        moved |= self.memory.center_mode.update_movement();
+        let delta_time = ui.ctx().input(|reader|reader.stable_dt);
+        moved |= self.memory.center_mode.update_movement(delta_time);
 
         if moved {
             response.mark_changed();

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -308,7 +308,7 @@ impl Widget for Map<'_, '_, '_> {
             ui.allocate_exact_size(ui.available_size(), Sense::click_and_drag());
 
         let mut moved = self.handle_gestures(ui, &response);
-        let delta_time = ui.ctx().input(|reader|reader.stable_dt);
+        let delta_time = ui.ctx().input(|reader| reader.stable_dt);
         moved |= self.memory.center_mode.update_movement(delta_time);
 
         if moved {


### PR DESCRIPTION
 This is just a slight change in how the map slows down during inertial moves. I have switched to having the speed decrease exponentially (like a first order exponential low-pass filter) rather than the linear decrease there is now. I personally prefer how this feels to use.

 * [X] Map is displaying and reacting to input correctly, both natively and on the web.
 * [X] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
