### PR TITLE
Expose MaxParallelDownloads

### DIFF
--- a/walkers/src/lib.rs
+++ b/walkers/src/lib.rs
@@ -13,7 +13,7 @@ pub mod sources;
 mod tiles;
 mod zoom;
 
-pub use download::{HeaderValue, HttpOptions};
+pub use download::{HeaderValue, HttpOptions, MaxParallelDownloads};
 pub use http_tiles::{HttpStats, HttpTiles};
 pub use map::{Map, MapMemory, Plugin, Projector};
 pub use position::{lat_lon, lon_lat, Position};


### PR DESCRIPTION
This allows manually creating the `HttpOptions` struct by exposing `MaxParallelDownloads`.
![image](https://github.com/user-attachments/assets/b08c3c6b-4d48-41af-aae3-24899f97d367)

The MaxParallelDownloads struct is declared with `pub`, but the module it is defined in is private. Meaning, it was not accessible directly. I added it to the `pub use` statement in `lib.rs` to expose it.

 * [x] Map is displaying and reacting to input correctly, both natively and on the web.
 * [x] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
