### PR TITLE
lock on Rust 1.84.0. Following egui.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.84.0"
+components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown", "aarch64-linux-android"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
+channel = "1.84.0"
 targets = ["wasm32-unknown-unknown", "aarch64-linux-android"]


### PR DESCRIPTION
 * [ ] Map is displaying and reacting to input correctly, both natively and on the web.
 * [ ] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
