### PR TITLE
add an option to disable panning even if zoom with ctrl is enabled

### DIFF
--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -58,6 +58,7 @@ pub struct Map<'a, 'b, 'c> {
     double_click_to_zoom: bool,
     double_click_to_zoom_out: bool,
     zoom_with_ctrl: bool,
+    disable_panning: bool,
 }
 
 impl<'a, 'b, 'c> Map<'a, 'b, 'c> {
@@ -78,6 +79,7 @@ impl<'a, 'b, 'c> Map<'a, 'b, 'c> {
             double_click_to_zoom: false,
             double_click_to_zoom_out: false,
             zoom_with_ctrl: true,
+            disable_panning: false,
         }
     }
 
@@ -141,6 +143,14 @@ impl<'a, 'b, 'c> Map<'a, 'b, 'c> {
     /// Has no effect on Android
     pub fn zoom_with_ctrl(mut self, enabled: bool) -> Self {
         self.zoom_with_ctrl = enabled;
+        self
+    }
+
+    /// Set if we can pan with mouse wheel.
+    /// By default, panning is disabled when zooming with ctrl is disabled.
+    /// Allow to disable panning even when zooming with ctrl is enabled.
+    pub fn disable_panning(mut self, disabled: bool) -> Self {
+        self.disable_panning = disabled;
         self
     }
 }
@@ -283,7 +293,7 @@ impl Map<'_, '_, '_> {
         }
 
         // Only enable panning with mouse_wheel if we are zooming with ctrl. But always allow touch devices to pan
-        let panning_enabled = ui.input(|i| i.any_touches()) || self.zoom_with_ctrl;
+        let panning_enabled = !self.disable_panning && (ui.input(|i| i.any_touches()) || self.zoom_with_ctrl);
 
         if ui.ui_contains_pointer() && panning_enabled {
             // Panning by scrolling, e.g. two-finger drag on a touchpad:


### PR DESCRIPTION
 * [X] Map is displaying and reacting to input correctly, both natively and on the web.
 * [X] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).

Add the option to disable the panning even if we have the zoom with control behaviour activated.
Allow to use scrolling for something else.
Can also be added to `zoom_with_ctrl` as an additional argument but dunno what's the best.
