### PR TITLE
Stick to my position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* When map is dragged while not being in a detached state, it will get pulled back to `my_position`,
+  unless certain threshold is reached.
+
 ## 0.39.0
 
 Please note that places plugin family are now being intensively refactored and might change pretty

--- a/walkers/src/center.rs
+++ b/walkers/src/center.rs
@@ -9,7 +9,7 @@ use crate::{
 const INERTIA_TAU: f32 = 0.2f32;
 
 /// Threshold for pulling the map back to `my_position` after dragging.
-const PULL_TO_MY_POSITION_THRESHOLD: f64 = 20.0;
+const PULL_TO_MY_POSITION_THRESHOLD: f32 = 20.0;
 
 /// Position of the map's center. Initially, the map follows `my_position` argument which typically
 /// is meant to be fed by a GPS sensor or other geo-localization method. If user drags the map,

--- a/walkers/src/center.rs
+++ b/walkers/src/center.rs
@@ -8,6 +8,9 @@ use crate::{
 /// Time constant of inertia stopping filter
 const INERTIA_TAU: f32 = 0.2f32;
 
+/// Threshold for pulling the map back to `my_position` after dragging.
+const PULL_TO_MY_POSITION_THRESHOLD: f64 = 20.0;
+
 /// Position of the map's center. Initially, the map follows `my_position` argument which typically
 /// is meant to be fed by a GPS sensor or other geo-localization method. If user drags the map,
 /// it becomes "detached" and stays this way until [`MapMemory::center_mode`] is changed back to
@@ -37,7 +40,7 @@ pub(crate) enum Center {
         amount: f32,
     },
 
-    /// Map is being pulled towards the `my_position`. This happens when the user releases the
+    /// Map is being pulled back to the `my_position`. This happens when the user releases the
     /// dragging gesture, but the map is too close to the `my_position`.
     PulledToMyPosition(AdjustedPosition),
 }
@@ -79,8 +82,8 @@ impl Center {
             from_detached,
         } = &self
         {
-            // Depending on the distance, map can be either pushed away or pulled back to `my_position`.
-            if *from_detached || position.offset.to_vec2().length() > 20.0 {
+            if *from_detached || position.offset.to_vec2().length() > PULL_TO_MY_POSITION_THRESHOLD
+            {
                 *self = Center::Inertia {
                     position: position.clone(),
                     direction: direction.normalized(),

--- a/walkers/src/center.rs
+++ b/walkers/src/center.rs
@@ -8,7 +8,7 @@ use crate::{
 /// Time constant of inertia stopping filter
 const INERTIA_TAU: f32 = 0.2f32;
 
-/// Position at the map's center. Initially, the map follows `my_position` argument which typically
+/// Position of the map's center. Initially, the map follows `my_position` argument which typically
 /// is meant to be fed by a GPS sensor or other geo-localization method. If user drags the map,
 /// it becomes "detached" and stays this way until [`MapMemory::center_mode`] is changed back to
 /// [`Center::MyPosition`].
@@ -37,7 +37,7 @@ pub(crate) enum Center {
 }
 
 impl Center {
-    pub(crate) fn recalculate_drag(&mut self, response: &Response, my_position: Position) -> bool {
+    pub(crate) fn handle_gestures(&mut self, response: &Response, my_position: Position) -> bool {
         if response.dragged_by(egui::PointerButton::Primary) {
             *self = Center::Moving {
                 position: self

--- a/walkers/src/center.rs
+++ b/walkers/src/center.rs
@@ -43,10 +43,23 @@ pub(crate) enum Center {
 }
 
 impl Center {
+    pub(crate) fn handle_gestures(&mut self, response: &Response, my_position: Position) -> bool {
+        if response.dragged_by(egui::PointerButton::Primary) {
+            self.dragged_by(my_position, response);
+            true
+        } else if response.drag_stopped() {
+            self.drag_stopped();
+            true
+        } else {
+            false
+        }
+    }
+
     fn dragged_by(&mut self, my_position: Position, response: &Response) {
         let from_detached = if let Center::Moving { from_detached, .. } = self {
             *from_detached
         } else {
+            // Only `MyPosition` state has no adjusted position.
             self.adjusted_position().is_some()
         };
 
@@ -76,18 +89,6 @@ impl Center {
             } else {
                 *self = Center::PulledToMyPosition(position.to_owned());
             }
-        }
-    }
-
-    pub(crate) fn handle_gestures(&mut self, response: &Response, my_position: Position) -> bool {
-        if response.dragged_by(egui::PointerButton::Primary) {
-            self.dragged_by(my_position, response);
-            true
-        } else if response.drag_stopped() {
-            self.drag_stopped();
-            true
-        } else {
-            false
         }
     }
 

--- a/walkers/src/center.rs
+++ b/walkers/src/center.rs
@@ -22,13 +22,13 @@ pub(crate) enum Center {
     /// Centered at the exact position.
     Exact(AdjustedPosition),
 
-    /// Map is currently being dragged.
+    /// Map is being dragged by mouse or finger.
     Moving {
         position: AdjustedPosition,
         direction: Vec2,
     },
 
-    /// Map is currently moving due to inertia, and will slow down and stop after a short while.
+    /// Map is moving, but due to inertia, and will slow down and stop in a short while.
     Inertia {
         position: AdjustedPosition,
         direction: Vec2,

--- a/walkers/src/download.rs
+++ b/walkers/src/download.rs
@@ -66,7 +66,7 @@ pub struct MaxParallelDownloads(pub usize);
 
 impl Default for MaxParallelDownloads {
     /// Default number of parallel downloads. Following modern browsers' behavior.
-    /// https://stackoverflow.com/questions/985431/max-parallel-http-connections-in-a-browser
+    /// <https://stackoverflow.com/questions/985431/max-parallel-http-connections-in-a-browser>
     fn default() -> Self {
         Self(6)
     }

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -202,7 +202,7 @@ impl Map<'_, '_, '_> {
             changed = self
                 .memory
                 .center_mode
-                .recalculate_drag(response, self.my_position);
+                .handle_gestures(response, self.my_position);
         }
 
         // Only enable panning with mouse_wheel if we are zooming with ctrl. But always allow touch devices to pan

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -44,6 +44,10 @@ struct Layer<'a> {
 ///     ));
 /// }
 /// ```
+///
+/// Initially, the map follows `my_position` argument which is typically fed by a GPS sensor or
+/// other geo-localization method. If user drags the map, it enters a "detached state". You can use
+/// [`MapMemory`]'s methods to change the state programmatically.
 pub struct Map<'a, 'b, 'c> {
     tiles: Option<&'b mut dyn Tiles>,
     layers: Vec<Layer<'b>>,


### PR DESCRIPTION
 * [ ] Map is displaying and reacting to input correctly, both natively and on the web.
 * [ ] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
