### PR TITLE
Stick to my_position when zooming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-* When map is dragged while not being in a detached state, it will get pulled back to `my_position`,
-  unless certain threshold is reached.
+* When map is dragged or zoomed while not being in a detached state, it will get pulled back to
+  `my_position`, unless offset reaches a certain threshold.
 
 ## 0.39.0
 

--- a/walkers/src/center.rs
+++ b/walkers/src/center.rs
@@ -8,8 +8,8 @@ use crate::{
 /// Time constant of inertia stopping filter
 const INERTIA_TAU: f32 = 0.2f32;
 
-/// Threshold for pulling the map back to `my_position` after dragging.
-const PULL_TO_MY_POSITION_THRESHOLD: f32 = 20.0;
+/// Threshold for pulling the map back to `my_position` after dragging or zooming.
+pub(crate) const PULL_TO_MY_POSITION_THRESHOLD: f32 = 20.0;
 
 /// Position of the map's center. Initially, the map follows `my_position` argument which typically
 /// is meant to be fed by a GPS sensor or other geo-localization method. If user drags the map,

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -1,7 +1,7 @@
 use egui::{PointerButton, Response, Sense, Ui, UiBuilder, Vec2, Widget};
 
 use crate::{
-    center::Center,
+    center::{Center, PULL_TO_MY_POSITION_THRESHOLD},
     position::AdjustedPosition,
     tiles::draw_tiles,
     zoom::{InvalidZoom, Zoom},
@@ -177,11 +177,16 @@ impl Map<'_, '_, '_> {
             // then adjust zoom level, finally move the location back to the original screen
             // position.
             if let Some(offset) = offset {
-                self.memory.center_mode = Center::Exact(
-                    AdjustedPosition::from(self.position())
-                        .shift(-offset)
-                        .zero_offset(self.memory.zoom()),
-                );
+                // If map is tracking `my_position` and the input offset is close, just let it be.
+                if self.memory.detached().is_some()
+                    || offset.length() > PULL_TO_MY_POSITION_THRESHOLD
+                {
+                    self.memory.center_mode = Center::Exact(
+                        AdjustedPosition::from(self.position())
+                            .shift(-offset)
+                            .zero_offset(self.memory.zoom()),
+                    );
+                }
             }
 
             // Shift by 1 because of the values given by zoom_delta(). Multiple by zoom_speed(defaults to 2.0),


### PR DESCRIPTION
 * [x] Map is displaying and reacting to input correctly, both natively and on the web.
 * [x] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
