### PR TITLE
memory module

### DIFF
--- a/walkers/src/lib.rs
+++ b/walkers/src/lib.rs
@@ -7,6 +7,7 @@ pub mod extras;
 mod http_tiles;
 mod io;
 mod map;
+mod memory;
 mod mercator;
 mod position;
 mod projector;
@@ -16,7 +17,8 @@ mod zoom;
 
 pub use download::{HeaderValue, HttpOptions, MaxParallelDownloads};
 pub use http_tiles::{HttpStats, HttpTiles};
-pub use map::{Map, MapMemory, Plugin};
+pub use map::{Map, Plugin};
+pub use memory::MapMemory;
 pub use position::{lat_lon, lon_lat, Position};
 pub use projector::Projector;
 pub use tiles::{Texture, TextureWithUv, TileId, Tiles};

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -4,8 +4,7 @@ use crate::{
     center::{Center, PULL_TO_MY_POSITION_THRESHOLD},
     position::AdjustedPosition,
     tiles::draw_tiles,
-    zoom::{InvalidZoom, Zoom},
-    Position, Projector, Tiles,
+    MapMemory, Position, Projector, Tiles,
 };
 
 /// Plugins allow drawing custom shapes on the map. After implementing this trait for your type,
@@ -300,59 +299,6 @@ impl Widget for Map<'_, '_, '_> {
         }
 
         response
-    }
-}
-
-/// State of the map widget which must persist between frames.
-#[derive(Debug, Default, Clone)]
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
-pub struct MapMemory {
-    pub(crate) center_mode: Center,
-    zoom: Zoom,
-}
-
-impl MapMemory {
-    /// Try to zoom in, returning `Err(InvalidZoom)` if already at maximum.
-    pub fn zoom_in(&mut self) -> Result<(), InvalidZoom> {
-        self.center_mode = self.center_mode.clone().zero_offset(self.zoom.into());
-        self.zoom.zoom_in()
-    }
-
-    /// Try to zoom out, returning `Err(InvalidZoom)` if already at minimum.
-    pub fn zoom_out(&mut self) -> Result<(), InvalidZoom> {
-        self.center_mode = self.center_mode.clone().zero_offset(self.zoom.into());
-        self.zoom.zoom_out()
-    }
-
-    /// Set exact zoom level
-    pub fn set_zoom(&mut self, zoom: f64) -> Result<(), InvalidZoom> {
-        self.center_mode = self.center_mode.clone().zero_offset(self.zoom.into());
-        self.zoom = Zoom::try_from(zoom)?;
-        Ok(())
-    }
-
-    /// Returns the current zoom level
-    pub fn zoom(&self) -> f64 {
-        self.zoom.into()
-    }
-
-    /// Returns exact position if map is detached (i.e. not following `my_position`),
-    /// `None` otherwise.
-    pub fn detached(&self) -> Option<Position> {
-        self.center_mode.detached(self.zoom.into())
-    }
-
-    /// Center exactly at the given position.
-    pub fn center_at(&mut self, position: Position) {
-        self.center_mode = Center::Exact(AdjustedPosition {
-            position,
-            offset: Default::default(),
-        });
-    }
-
-    /// Follow `my_position`.
-    pub fn follow_my_position(&mut self) {
-        self.center_mode = Center::MyPosition;
     }
 }
 

--- a/walkers/src/memory.rs
+++ b/walkers/src/memory.rs
@@ -1,0 +1,54 @@
+use crate::{center::Center, position::AdjustedPosition, zoom::Zoom, InvalidZoom, Position};
+
+/// State of the map widget which must persist between frames.
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+pub struct MapMemory {
+    pub(crate) center_mode: Center,
+    pub(crate) zoom: Zoom,
+}
+
+impl MapMemory {
+    /// Try to zoom in, returning `Err(InvalidZoom)` if already at maximum.
+    pub fn zoom_in(&mut self) -> Result<(), InvalidZoom> {
+        self.center_mode = self.center_mode.clone().zero_offset(self.zoom.into());
+        self.zoom.zoom_in()
+    }
+
+    /// Try to zoom out, returning `Err(InvalidZoom)` if already at minimum.
+    pub fn zoom_out(&mut self) -> Result<(), InvalidZoom> {
+        self.center_mode = self.center_mode.clone().zero_offset(self.zoom.into());
+        self.zoom.zoom_out()
+    }
+
+    /// Set exact zoom level
+    pub fn set_zoom(&mut self, zoom: f64) -> Result<(), InvalidZoom> {
+        self.center_mode = self.center_mode.clone().zero_offset(self.zoom.into());
+        self.zoom = Zoom::try_from(zoom)?;
+        Ok(())
+    }
+
+    /// Returns the current zoom level
+    pub fn zoom(&self) -> f64 {
+        self.zoom.into()
+    }
+
+    /// Returns exact position if map is detached (i.e. not following `my_position`),
+    /// `None` otherwise.
+    pub fn detached(&self) -> Option<Position> {
+        self.center_mode.detached(self.zoom.into())
+    }
+
+    /// Center exactly at the given position.
+    pub fn center_at(&mut self, position: Position) {
+        self.center_mode = Center::Exact(AdjustedPosition {
+            position,
+            offset: Default::default(),
+        });
+    }
+
+    /// Follow `my_position`.
+    pub fn follow_my_position(&mut self) {
+        self.center_mode = Center::MyPosition;
+    }
+}


### PR DESCRIPTION
 * [ ] Map is displaying and reacting to input correctly, both natively and on the web.
 * [ ] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
