### PR TITLE
Labeled symbol improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 * `LabeledSymbolGroup` now has the `style` field, which allows changing how the group looks.
 * `LabeledSymbol::symbol` is now optional and can have a different types. See `Symbol` enum
   for possible values.
+* `LabeledSymbolStyle::label_corner_radius` is now a field, allowing to set the corner radius
+  of the label background rectangle.
 
 ## 0.40.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable changes to this project will be documented in this file.
 * `GroupedPlaces` now takes an instance of `Group` (e.g. `LabeledSymbolGroup`), which allows
   groups to be customized.
 * `LabeledSymbolGroup` now has the `style` field, which allows changing how the group looks.
-* `LabeledSymbol::symbol` is now optional.
+* `LabeledSymbol::symbol` is now optional and can have a different types. See `Symbol` enum
+  for possible values.
 
 ## 0.40.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ All notable changes to this project will be documented in this file.
 * `LabeledSymbolGroup` now has the `style` field, which allows changing how the group looks.
 * `LabeledSymbol::symbol` is now optional and can have a different types. See `Symbol` enum
   for possible values.
-* `LabeledSymbolStyle::label_corner_radius` is now a field, allowing to set the corner radius
-  of the label background rectangle.
+* `LabeledSymbolStyle` has new fields `label_corner_radius` and `symbol_size`.
 
 ## 0.40.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 * `GroupedPlaces` now takes an instance of `Group` (e.g. `LabeledSymbolGroup`), which allows
   groups to be customized.
 * `LabeledSymbolGroup` now has the `style` field, which allows changing how the group looks.
+* `LabeledSymbol::symbol` is now optional.
 
 ## 0.40.0
 

--- a/demo/src/places.rs
+++ b/demo/src/places.rs
@@ -25,3 +25,8 @@ pub fn capitol() -> Position {
 pub fn wroclavia() -> Position {
     lon_lat(17.03471, 51.09648)
 }
+
+/// Main square of the city, with many restaurants and historical buildings.
+pub fn rynek() -> Position {
+    lon_lat(17.032094, 51.110090)
+}

--- a/demo/src/plugins.rs
+++ b/demo/src/plugins.rs
@@ -17,7 +17,10 @@ pub fn places() -> impl Plugin {
                 position: places::wroclaw_glowny(),
                 label: "Wrocław Główny\ntrain station".to_owned(),
                 symbol: Some(Symbol::Circle('🚆')),
-                style: LabeledSymbolStyle::default(),
+                style: LabeledSymbolStyle {
+                    symbol_size: 20.,
+                    ..Default::default()
+                },
             },
             LabeledSymbol {
                 position: places::dworcowa_bus_stop(),
@@ -25,6 +28,8 @@ pub fn places() -> impl Plugin {
                 symbol: Some(Symbol::TwoCorners),
                 style: LabeledSymbolStyle {
                     label_corner_radius: 2.,
+                    symbol_size: 8.,
+                    symbol_background: Color32::WHITE.gamma_multiply(0.4),
                     ..Default::default()
                 },
             },

--- a/demo/src/plugins.rs
+++ b/demo/src/plugins.rs
@@ -18,17 +18,17 @@ pub fn places() -> impl Plugin {
                 label: "Wrocław Główny\ntrain station".to_owned(),
                 symbol: Some(Symbol::Circle("🚆".to_string())),
                 style: LabeledSymbolStyle {
-                    symbol_size: 20.,
+                    symbol_size: 18.,
                     ..Default::default()
                 },
             },
             LabeledSymbol {
                 position: places::dworcowa_bus_stop(),
                 label: "Bus stop".to_owned(),
-                symbol: Some(Symbol::TwoCorners),
+                symbol: Some(Symbol::TwoCorners(String::from("🚌"))),
                 style: LabeledSymbolStyle {
                     label_corner_radius: 2.,
-                    symbol_size: 8.,
+                    symbol_size: 18.,
                     symbol_background: Color32::WHITE.gamma_multiply(0.4),
                     ..Default::default()
                 },

--- a/demo/src/plugins.rs
+++ b/demo/src/plugins.rs
@@ -18,7 +18,7 @@ pub fn places() -> impl Plugin {
                 label: "Wrocław Główny\ntrain station".to_owned(),
                 symbol: Some(Symbol::Circle("🚆".to_string())),
                 style: LabeledSymbolStyle {
-                    symbol_size: 18.,
+                    symbol_size: 25.,
                     ..Default::default()
                 },
             },

--- a/demo/src/plugins.rs
+++ b/demo/src/plugins.rs
@@ -2,7 +2,7 @@ use egui::{Color32, Response, Ui};
 use walkers::{
     extras::{
         GroupedPlaces, Image, LabeledSymbol, LabeledSymbolGroup, LabeledSymbolGroupStyle,
-        LabeledSymbolStyle, Places, Texture,
+        LabeledSymbolStyle, Places, Symbol, Texture,
     },
     MapMemory, Plugin, Position, Projector,
 };
@@ -16,13 +16,14 @@ pub fn places() -> impl Plugin {
             LabeledSymbol {
                 position: places::wroclaw_glowny(),
                 label: "Wrocław Główny\ntrain station".to_owned(),
-                symbol: Some('🚆'),
+                symbol: Some(Symbol::Circle('🚆')),
                 style: LabeledSymbolStyle::default(),
             },
             LabeledSymbol {
                 position: places::dworcowa_bus_stop(),
                 label: "Bus stop".to_owned(),
-                symbol: Some('🚌'),
+                //symbol: Some(Symbol('🚌')),
+                symbol: Some(Symbol::TwoCorners),
                 style: LabeledSymbolStyle::default(),
             },
             LabeledSymbol {

--- a/demo/src/plugins.rs
+++ b/demo/src/plugins.rs
@@ -22,9 +22,11 @@ pub fn places() -> impl Plugin {
             LabeledSymbol {
                 position: places::dworcowa_bus_stop(),
                 label: "Bus stop".to_owned(),
-                //symbol: Some(Symbol('🚌')),
                 symbol: Some(Symbol::TwoCorners),
-                style: LabeledSymbolStyle::default(),
+                style: LabeledSymbolStyle {
+                    label_corner_radius: 2.,
+                    ..Default::default()
+                },
             },
             LabeledSymbol {
                 position: places::rynek(),

--- a/demo/src/plugins.rs
+++ b/demo/src/plugins.rs
@@ -16,7 +16,7 @@ pub fn places() -> impl Plugin {
             LabeledSymbol {
                 position: places::wroclaw_glowny(),
                 label: "Wrocław Główny\ntrain station".to_owned(),
-                symbol: Some(Symbol::Circle('🚆')),
+                symbol: Some(Symbol::Circle("🚆".to_string())),
                 style: LabeledSymbolStyle {
                     symbol_size: 20.,
                     ..Default::default()

--- a/demo/src/plugins.rs
+++ b/demo/src/plugins.rs
@@ -16,13 +16,19 @@ pub fn places() -> impl Plugin {
             LabeledSymbol {
                 position: places::wroclaw_glowny(),
                 label: "Wrocław Główny\ntrain station".to_owned(),
-                symbol: '🚆',
+                symbol: Some('🚆'),
                 style: LabeledSymbolStyle::default(),
             },
             LabeledSymbol {
                 position: places::dworcowa_bus_stop(),
                 label: "Bus stop".to_owned(),
-                symbol: '🚌',
+                symbol: Some('🚌'),
+                style: LabeledSymbolStyle::default(),
+            },
+            LabeledSymbol {
+                position: places::rynek(),
+                label: "Rynek".to_owned(),
+                symbol: None,
                 style: LabeledSymbolStyle::default(),
             },
         ],

--- a/walkers/src/extras/labeled_symbol.rs
+++ b/walkers/src/extras/labeled_symbol.rs
@@ -50,15 +50,21 @@ impl Place for LabeledSymbol {
 
         painter.galley((screen_position + offset).to_pos2(), label, Color32::BLACK);
 
+        self.draw_symbol(painter, screen_position.to_pos2());
+    }
+}
+
+impl LabeledSymbol {
+    fn draw_symbol(&self, painter: &egui::Painter, screen_position: egui::Pos2) {
         painter.circle(
-            screen_position.to_pos2(),
+            screen_position,
             10.,
             self.style.symbol_background,
             self.style.symbol_stroke,
         );
 
         painter.text(
-            screen_position.to_pos2(),
+            screen_position,
             Align2::CENTER_CENTER,
             self.symbol.to_string(),
             self.style.symbol_font.clone(),

--- a/walkers/src/extras/labeled_symbol.rs
+++ b/walkers/src/extras/labeled_symbol.rs
@@ -58,7 +58,7 @@ impl LabeledSymbol {
     ) {
         painter.circle(
             screen_position,
-            10.,
+            self.style.symbol_size / 2.,
             self.style.symbol_background,
             self.style.symbol_stroke,
         );

--- a/walkers/src/extras/labeled_symbol.rs
+++ b/walkers/src/extras/labeled_symbol.rs
@@ -13,7 +13,7 @@ pub struct LabeledSymbol {
 
     /// Symbol drawn on the place. You can check [egui's font book](https://www.egui.rs/) to pick
     /// a desired character.
-    pub symbol: char,
+    pub symbol: Option<char>,
 
     /// Visual style of this place.
     pub style: LabeledSymbolStyle,
@@ -29,12 +29,15 @@ impl Place for LabeledSymbol {
         let painter = ui.painter();
 
         self.draw_label(painter, screen_position);
-        self.draw_symbol(painter, screen_position.to_pos2());
+
+        if let Some(symbol) = self.symbol {
+            self.draw_symbol(symbol, painter, screen_position.to_pos2());
+        }
     }
 }
 
 impl LabeledSymbol {
-    fn draw_symbol(&self, painter: &egui::Painter, screen_position: egui::Pos2) {
+    fn draw_symbol(&self, symbol: char, painter: &egui::Painter, screen_position: egui::Pos2) {
         painter.circle(
             screen_position,
             10.,
@@ -45,7 +48,7 @@ impl LabeledSymbol {
         painter.text(
             screen_position,
             Align2::CENTER_CENTER,
-            self.symbol.to_string(),
+            symbol.to_string(),
             self.style.symbol_font.clone(),
             self.style.symbol_color,
         );

--- a/walkers/src/extras/labeled_symbol.rs
+++ b/walkers/src/extras/labeled_symbol.rs
@@ -35,7 +35,9 @@ impl Place for LabeledSymbol {
         let screen_position = projector.project(self.position);
         let painter = ui.painter();
 
-        self.draw_label(painter, screen_position);
+        if !self.label.is_empty() {
+            self.draw_label(painter, screen_position);
+        }
 
         match self.symbol {
             Some(Symbol::Circle(ref text)) => {

--- a/walkers/src/extras/labeled_symbol.rs
+++ b/walkers/src/extras/labeled_symbol.rs
@@ -5,7 +5,7 @@ use egui::{vec2, Align2, Color32, FontId, Stroke, Ui};
 #[derive(Clone)]
 /// Type of the symbol of a [`LabeledSymbol`].
 pub enum Symbol {
-    Circle(char),
+    Circle(String),
     TwoCorners,
 }
 
@@ -38,7 +38,7 @@ impl Place for LabeledSymbol {
         self.draw_label(painter, screen_position);
 
         match self.symbol {
-            Some(Symbol::Circle(symbol)) => {
+            Some(Symbol::Circle(ref symbol)) => {
                 self.draw_circle_symbol(symbol, painter, screen_position.to_pos2())
             }
             Some(Symbol::TwoCorners) => {
@@ -52,7 +52,7 @@ impl Place for LabeledSymbol {
 impl LabeledSymbol {
     fn draw_circle_symbol(
         &self,
-        symbol: char,
+        symbol: &str,
         painter: &egui::Painter,
         screen_position: egui::Pos2,
     ) {

--- a/walkers/src/extras/labeled_symbol.rs
+++ b/walkers/src/extras/labeled_symbol.rs
@@ -38,8 +38,8 @@ impl Place for LabeledSymbol {
         self.draw_label(painter, screen_position);
 
         match self.symbol {
-            Some(Symbol::Circle(ref symbol)) => {
-                self.draw_circle_symbol(symbol, painter, screen_position.to_pos2())
+            Some(Symbol::Circle(ref text)) => {
+                self.draw_circle_symbol(text.clone(), painter, screen_position.to_pos2())
             }
             Some(Symbol::TwoCorners(ref text)) => {
                 self.draw_two_corners_symbol(text.clone(), painter, screen_position.to_pos2())
@@ -52,7 +52,7 @@ impl Place for LabeledSymbol {
 impl LabeledSymbol {
     fn draw_circle_symbol(
         &self,
-        symbol: &str,
+        text: String,
         painter: &egui::Painter,
         screen_position: egui::Pos2,
     ) {
@@ -66,7 +66,7 @@ impl LabeledSymbol {
         painter.text(
             screen_position,
             Align2::CENTER_CENTER,
-            symbol.to_string(),
+            text,
             self.style.symbol_font.clone(),
             self.style.symbol_color,
         );

--- a/walkers/src/extras/labeled_symbol.rs
+++ b/walkers/src/extras/labeled_symbol.rs
@@ -3,6 +3,7 @@ use crate::{Position, Projector};
 use egui::{vec2, Align2, Color32, FontId, Stroke, Ui};
 
 #[derive(Clone)]
+/// Type of the symbol of a [`LabeledSymbol`].
 pub enum Symbol {
     Circle(char),
     TwoCorners,

--- a/walkers/src/extras/labeled_symbol.rs
+++ b/walkers/src/extras/labeled_symbol.rs
@@ -28,6 +28,30 @@ impl Place for LabeledSymbol {
         let screen_position = projector.project(self.position);
         let painter = ui.painter();
 
+        self.draw_label(painter, screen_position);
+        self.draw_symbol(painter, screen_position.to_pos2());
+    }
+}
+
+impl LabeledSymbol {
+    fn draw_symbol(&self, painter: &egui::Painter, screen_position: egui::Pos2) {
+        painter.circle(
+            screen_position,
+            10.,
+            self.style.symbol_background,
+            self.style.symbol_stroke,
+        );
+
+        painter.text(
+            screen_position,
+            Align2::CENTER_CENTER,
+            self.symbol.to_string(),
+            self.style.symbol_font.clone(),
+            self.style.symbol_color,
+        );
+    }
+
+    fn draw_label(&self, painter: &egui::Painter, screen_position: egui::Vec2) {
         let label = painter.layout_no_wrap(
             self.label.to_owned(),
             self.style.label_font.clone(),
@@ -49,27 +73,6 @@ impl Place for LabeledSymbol {
         );
 
         painter.galley((screen_position + offset).to_pos2(), label, Color32::BLACK);
-
-        self.draw_symbol(painter, screen_position.to_pos2());
-    }
-}
-
-impl LabeledSymbol {
-    fn draw_symbol(&self, painter: &egui::Painter, screen_position: egui::Pos2) {
-        painter.circle(
-            screen_position,
-            10.,
-            self.style.symbol_background,
-            self.style.symbol_stroke,
-        );
-
-        painter.text(
-            screen_position,
-            Align2::CENTER_CENTER,
-            self.symbol.to_string(),
-            self.style.symbol_font.clone(),
-            self.style.symbol_color,
-        );
     }
 }
 

--- a/walkers/src/extras/labeled_symbol.rs
+++ b/walkers/src/extras/labeled_symbol.rs
@@ -78,7 +78,6 @@ impl LabeledSymbol {
         let bottom_right = screen_position + vec2(half_size, half_size);
         let top_right = screen_position + vec2(half_size, -half_size);
         let bottom_left = screen_position + vec2(-half_size, half_size);
-
         let len = 4.;
 
         // Background rectangle.

--- a/walkers/src/extras/labeled_symbol.rs
+++ b/walkers/src/extras/labeled_symbol.rs
@@ -127,7 +127,7 @@ impl LabeledSymbol {
                 .translate(screen_position)
                 .translate(offset)
                 .expand(5.),
-            10.,
+            self.style.label_corner_radius,
             self.style.label_background,
         );
 
@@ -141,6 +141,7 @@ pub struct LabeledSymbolStyle {
     pub label_font: FontId,
     pub label_color: Color32,
     pub label_background: Color32,
+    pub label_corner_radius: f32,
     pub symbol_font: FontId,
     pub symbol_color: Color32,
     pub symbol_background: Color32,
@@ -153,6 +154,7 @@ impl Default for LabeledSymbolStyle {
             label_font: FontId::proportional(12.),
             label_color: Color32::from_gray(200),
             label_background: Color32::BLACK.gamma_multiply(0.8),
+            label_corner_radius: 10.,
             symbol_font: FontId::proportional(14.),
             symbol_color: Color32::BLACK.gamma_multiply(0.8),
             symbol_background: Color32::WHITE.gamma_multiply(0.8),

--- a/walkers/src/extras/labeled_symbol.rs
+++ b/walkers/src/extras/labeled_symbol.rs
@@ -38,7 +38,7 @@ impl Place for LabeledSymbol {
 
         match self.symbol {
             Some(Symbol::Circle(symbol)) => {
-                self.draw_symbol(symbol, painter, screen_position.to_pos2())
+                self.draw_circle_symbol(symbol, painter, screen_position.to_pos2())
             }
             Some(Symbol::TwoCorners) => {
                 self.draw_two_corners_symbol(painter, screen_position.to_pos2())
@@ -49,7 +49,12 @@ impl Place for LabeledSymbol {
 }
 
 impl LabeledSymbol {
-    fn draw_symbol(&self, symbol: char, painter: &egui::Painter, screen_position: egui::Pos2) {
+    fn draw_circle_symbol(
+        &self,
+        symbol: char,
+        painter: &egui::Painter,
+        screen_position: egui::Pos2,
+    ) {
         painter.circle(
             screen_position,
             10.,

--- a/walkers/src/extras/labeled_symbol.rs
+++ b/walkers/src/extras/labeled_symbol.rs
@@ -6,7 +6,7 @@ use egui::{vec2, Align2, Color32, FontId, Stroke, Ui};
 /// Type of the symbol of a [`LabeledSymbol`].
 pub enum Symbol {
     Circle(String),
-    TwoCorners,
+    TwoCorners(String),
 }
 
 /// A symbol with a label to be drawn on the map.
@@ -41,8 +41,8 @@ impl Place for LabeledSymbol {
             Some(Symbol::Circle(ref symbol)) => {
                 self.draw_circle_symbol(symbol, painter, screen_position.to_pos2())
             }
-            Some(Symbol::TwoCorners) => {
-                self.draw_two_corners_symbol(painter, screen_position.to_pos2())
+            Some(Symbol::TwoCorners(ref text)) => {
+                self.draw_two_corners_symbol(text.clone(), painter, screen_position.to_pos2())
             }
             None => {}
         }
@@ -72,7 +72,12 @@ impl LabeledSymbol {
         );
     }
 
-    fn draw_two_corners_symbol(&self, painter: &egui::Painter, screen_position: egui::Pos2) {
+    fn draw_two_corners_symbol(
+        &self,
+        text: String,
+        painter: &egui::Painter,
+        screen_position: egui::Pos2,
+    ) {
         let half_size = self.style.symbol_size / 2.;
         let top_left = screen_position + vec2(-half_size, -half_size);
         let bottom_right = screen_position + vec2(half_size, half_size);
@@ -105,6 +110,15 @@ impl LabeledSymbol {
         painter.line_segment(
             [bottom_left, bottom_left + vec2(0., -len)],
             self.style.symbol_stroke,
+        );
+
+        // Text.
+        painter.text(
+            screen_position,
+            Align2::CENTER_CENTER,
+            text.clone(),
+            self.style.symbol_font.clone(),
+            self.style.symbol_color,
         );
     }
 

--- a/walkers/src/extras/labeled_symbol.rs
+++ b/walkers/src/extras/labeled_symbol.rs
@@ -73,8 +73,7 @@ impl LabeledSymbol {
     }
 
     fn draw_two_corners_symbol(&self, painter: &egui::Painter, screen_position: egui::Pos2) {
-        let size = 10.;
-        let half_size = size / 2.;
+        let half_size = self.style.symbol_size / 2.;
         let top_left = screen_position + vec2(-half_size, -half_size);
         let bottom_right = screen_position + vec2(half_size, half_size);
         let top_right = screen_position + vec2(half_size, -half_size);
@@ -146,6 +145,7 @@ pub struct LabeledSymbolStyle {
     pub symbol_color: Color32,
     pub symbol_background: Color32,
     pub symbol_stroke: Stroke,
+    pub symbol_size: f32,
 }
 
 impl Default for LabeledSymbolStyle {
@@ -159,6 +159,7 @@ impl Default for LabeledSymbolStyle {
             symbol_color: Color32::BLACK.gamma_multiply(0.8),
             symbol_background: Color32::WHITE.gamma_multiply(0.8),
             symbol_stroke: Stroke::new(2., Color32::BLACK.gamma_multiply(0.8)),
+            symbol_size: 10.,
         }
     }
 }

--- a/walkers/src/extras/mod.rs
+++ b/walkers/src/extras/mod.rs
@@ -6,6 +6,6 @@ mod places;
 pub use crate::tiles::Texture;
 pub use image::Image;
 pub use labeled_symbol::{
-    LabeledSymbol, LabeledSymbolGroup, LabeledSymbolGroupStyle, LabeledSymbolStyle,
+    LabeledSymbol, LabeledSymbolGroup, LabeledSymbolGroupStyle, LabeledSymbolStyle, Symbol,
 };
 pub use places::{Group, GroupedPlaces, Place, Places};


### PR DESCRIPTION
 * [x] Map is displaying and reacting to input correctly, both natively and on the web.
 * [x] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).

![image](https://github.com/user-attachments/assets/80fa2d3d-39da-49eb-bf3f-c44410b7b2a3)

