### PR TITLE
Update MSRV to 1.85

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
   frame.
 * New `Map::pull_to_my_position_threshold` function for setting the threshold of the feature
   introduced in 0.40.0. It defaults to `0.0`, meaning that the map will not be pulled at all.
+* Bump MSRV to 1.85
 
 ## 0.41.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ resolver = "2"
 
 [workspace.package]
 version = "0.41.0"
+rust-version = "1.85" # Aligned to egui
 
 [workspace.dependencies]
 image = { version = "0.25", default-features = false }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.85.0"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown", "aarch64-linux-android"]


### PR DESCRIPTION
This PR bumps the MSRV to 1.85 to align with egui. This is in preparation for the (very soon) upcoming egui 0.32 release.

 * [x] Map is displaying and reacting to input correctly, both natively and on the web.
 * [x] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
