### PR TITLE
`Map::drag_pan_buttons` which allows configuring drag buttons.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* `Map::drag_gesture()` is replaced by `Map::drag_pan_buttons()`, which allows configuring which
+  mouse buttons can be used for dragging.
+
 ## 0.43.0
 
 * `egui` updated to 0.32.

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -7,7 +7,7 @@ mod windows;
 use std::collections::BTreeMap;
 
 use crate::plugins::ImagesPluginData;
-use egui::{CentralPanel, Context, Frame};
+use egui::{CentralPanel, Context, DragPanButtons, Frame};
 use tiles::{providers, Provider, TilesKind};
 use walkers::{Map, MapMemory};
 
@@ -54,7 +54,9 @@ impl eframe::App for MyApp {
             let mut map = Map::new(None, &mut self.map_memory, my_position);
 
             // Various aspects of the map can be configured.
-            map = map.zoom_with_ctrl(self.zoom_with_ctrl);
+            map = map
+                .zoom_with_ctrl(self.zoom_with_ctrl)
+                .drag_pan_buttons(DragPanButtons::PRIMARY | DragPanButtons::SECONDARY);
 
             // Optionally, plugins can be attached.
             map = map

--- a/walkers/src/center.rs
+++ b/walkers/src/center.rs
@@ -1,5 +1,5 @@
 use crate::{position::AdjustedPosition, Position};
-use egui::{Response, Vec2};
+use egui::{DragPanButtons, PointerButton, Response, Vec2};
 
 /// Time constant of inertia stopping filter
 const INERTIA_TAU: f32 = 0.2f32;
@@ -44,8 +44,9 @@ impl Center {
         response: &Response,
         my_position: Position,
         pull_to_my_position_threshold: f32,
+        drag_pan_buttons: DragPanButtons,
     ) -> bool {
-        if response.dragged_by(egui::PointerButton::Primary) {
+        if dragged_by(response, drag_pan_buttons) {
             self.dragged_by(my_position, response);
             true
         } else if response.drag_stopped() {
@@ -187,4 +188,15 @@ impl Center {
             },
         }
     }
+}
+
+fn dragged_by(response: &Response, buttons: DragPanButtons) -> bool {
+    buttons.iter().any(|button| match button {
+        DragPanButtons::PRIMARY => response.dragged_by(PointerButton::Primary),
+        DragPanButtons::SECONDARY => response.dragged_by(PointerButton::Secondary),
+        DragPanButtons::MIDDLE => response.dragged_by(PointerButton::Middle),
+        DragPanButtons::EXTRA_1 => response.dragged_by(PointerButton::Extra1),
+        DragPanButtons::EXTRA_2 => response.dragged_by(PointerButton::Extra2),
+        _ => false,
+    })
 }

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -1,4 +1,4 @@
-use egui::{PointerButton, Response, Sense, Ui, UiBuilder, Vec2, Widget};
+use egui::{DragPanButtons, PointerButton, Response, Sense, Ui, UiBuilder, Vec2, Widget};
 
 use crate::{
     center::Center, position::AdjustedPosition, tiles::draw_tiles, MapMemory, Position, Projector,
@@ -34,6 +34,7 @@ struct Layer<'a> {
 struct Options {
     zoom_gesture_enabled: bool,
     drag_gesture_enabled: bool,
+    drag_pan_buttons: DragPanButtons,
     zoom_speed: f64,
     double_click_to_zoom: bool,
     double_click_to_zoom_out: bool,
@@ -47,6 +48,7 @@ impl Default for Options {
         Self {
             zoom_gesture_enabled: true,
             drag_gesture_enabled: true,
+            drag_pan_buttons: DragPanButtons::PRIMARY,
             zoom_speed: 2.0,
             double_click_to_zoom: false,
             double_click_to_zoom_out: false,
@@ -129,6 +131,12 @@ impl<'a, 'b, 'c> Map<'a, 'b, 'c> {
     /// Set whether map should perform drag gesture.
     pub fn drag_gesture(mut self, enabled: bool) -> Self {
         self.options.drag_gesture_enabled = enabled;
+        self
+    }
+
+    /// Specify which pointer buttons can be used to pan by clicking and dragging.
+    pub fn drag_pan_buttons(mut self, buttons: DragPanButtons) -> Self {
+        self.options.drag_pan_buttons = buttons;
         self
     }
 
@@ -234,6 +242,7 @@ impl Map<'_, '_, '_> {
                 response,
                 self.my_position,
                 self.options.pull_to_my_position_threshold,
+                self.options.drag_pan_buttons,
             );
         }
 


### PR DESCRIPTION
 * [ ] Map is displaying and reacting to input correctly, both natively and on the web.
 * [ ] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).

Closes https://github.com/podusowski/walkers/issues/349
Closes https://github.com/podusowski/walkers/issues/134