### PR TITLE
pass `MapMemory` to the `Map::show()`'s closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* `Map::show()` now passes `&MapMemory` to the closure.
+
 ## 0.44.0
 
 * New `Map::show()` function. It takes a closure that can draw custom content on the map. It is

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -73,7 +73,7 @@ impl eframe::App for MyApp {
             }
 
             // Draw the map widget.
-            let response = map.show(ui, |ui, projector| {
+            let response = map.show(ui, |ui, projector, _| {
                 // You can add any additional contents to the map's UI here.
                 let bastion = projector.project(places::bastion_sakwowy()).to_pos2();
                 ui.put(

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -188,7 +188,7 @@ impl<'a, 'b, 'c> Map<'a, 'b, 'c> {
     pub fn show<R>(
         mut self,
         ui: &mut Ui,
-        add_contents: impl FnOnce(&mut Ui, &Projector) -> R,
+        add_contents: impl FnOnce(&mut Ui, &Projector, &MapMemory) -> R,
     ) -> InnerResponse<R> {
         let (rect, mut response) =
             ui.allocate_exact_size(ui.available_size(), Sense::click_and_drag());
@@ -225,7 +225,7 @@ impl<'a, 'b, 'c> Map<'a, 'b, 'c> {
         }
 
         let mut child_ui = ui.new_child(UiBuilder::new().max_rect(rect).id_salt("inner"));
-        let inner = add_contents(&mut child_ui, &projector);
+        let inner = add_contents(&mut child_ui, &projector, self.memory);
 
         InnerResponse { inner, response }
     }
@@ -337,7 +337,7 @@ impl Map<'_, '_, '_> {
 
 impl Widget for Map<'_, '_, '_> {
     fn ui(self, ui: &mut Ui) -> Response {
-        self.show(ui, |_, _| ()).response
+        self.show(ui, |_, _, _| ()).response
     }
 }
 


### PR DESCRIPTION
 * [ ] Map is displaying and reacting to input correctly, both natively and on the web.
 * [ ] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
