### PR TITLE
Fix high fps zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 * New `LocalTiles` implementation for loading tiles from a local directory.
+* Fixed zooming on high refresh rates.
 
 ## 0.45.0
 

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -238,7 +238,7 @@ impl Map<'_, '_, '_> {
 
         // Zooming and dragging need to be exclusive, otherwise the map will get dragged when
         // pinch gesture is used.
-        let changed = if (zoom_delta - 1.0).abs() > 0.01
+        let changed = if (zoom_delta - 1.0).abs() > 0.001
             && ui.ui_contains_pointer()
             && self.options.zoom_gesture_enabled
         {
@@ -323,7 +323,7 @@ impl Map<'_, '_, '_> {
             // We only use the raw scroll values, if we are zooming without ctrl,
             // and zoom_delta is not already over/under 1.0 (eg. a ctrl + scroll event or a pinch zoom)
             // These values seem to correspond to the same values as one would get in `zoom_delta()`
-            zoom_delta = ui.input(|input| (1.0 + input.smooth_scroll_delta.y / 200.0)) as f64
+            zoom_delta = ui.input(|input| (1.0 + input.smooth_scroll_delta.y * input.stable_dt.max(input.predicted_dt * 1.5) / 4.0)) as f64
         };
 
         zoom_delta

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -323,7 +323,10 @@ impl Map<'_, '_, '_> {
             // We only use the raw scroll values, if we are zooming without ctrl,
             // and zoom_delta is not already over/under 1.0 (eg. a ctrl + scroll event or a pinch zoom)
             // These values seem to correspond to the same values as one would get in `zoom_delta()`
-            zoom_delta = ui.input(|input| (1.0 + input.smooth_scroll_delta.y * input.stable_dt.max(input.predicted_dt * 1.5) / 4.0)) as f64
+            zoom_delta = 1f64
+                + ui.input(|input| {
+                    input.smooth_scroll_delta.y * input.stable_dt.max(input.predicted_dt * 1.5)
+                }) as f64 / 4.0;
         };
 
         zoom_delta

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -326,7 +326,8 @@ impl Map<'_, '_, '_> {
             zoom_delta = 1f64
                 + ui.input(|input| {
                     input.smooth_scroll_delta.y * input.stable_dt.max(input.predicted_dt * 1.5)
-                }) as f64 / 4.0;
+                }) as f64
+                    / 4.0;
         };
 
         zoom_delta


### PR DESCRIPTION
Fixes https://github.com/podusowski/walkers/issues/306 by using deltatime for the zoom speed falloff.

https://github.com/user-attachments/assets/44ceccd2-b68e-4c43-a149-b0f325e830d7

The numbers used are magic numbers that felt the best, feel free to slightly change them.
I have not tested web, but it should not have any regressions.

 * [ ] Map is displaying and reacting to input correctly, both natively and on the web.
 * [x] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).