### PR TITLE
show cpu usage

### DIFF
--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -105,7 +105,7 @@ impl eframe::App for MyApp {
                     })
                     .collect();
 
-                controls(self, ui, http_stats);
+                controls(self, ui, http_stats, _frame);
                 acknowledge(ui, attributions);
             }
         });

--- a/demo/src/windows.rs
+++ b/demo/src/windows.rs
@@ -23,7 +23,12 @@ pub fn acknowledge(ui: &Ui, attributions: Vec<Attribution>) {
         });
 }
 
-pub fn controls(app: &mut MyApp, ui: &Ui, http_stats: Vec<walkers::HttpStats>) {
+pub fn controls(
+    app: &mut MyApp,
+    ui: &Ui,
+    http_stats: Vec<walkers::HttpStats>,
+    frame: &mut eframe::Frame,
+) {
     Window::new("Controls")
         .collapsible(false)
         .resizable(false)
@@ -67,6 +72,10 @@ pub fn controls(app: &mut MyApp, ui: &Ui, http_stats: Vec<walkers::HttpStats>) {
                     "{:?} requests in progress: {}",
                     app.selected_provider, http_stats.in_progress
                 ));
+            }
+
+            if let Some(cpu_usage) = frame.info().cpu_usage {
+                ui.label(format!("CPU usage: {:.2}ms", cpu_usage * 1000.0));
             }
         });
 }


### PR DESCRIPTION
 * [ ] Map is displaying and reacting to input correctly, both natively and on the web.
 * [ ] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
