### PR TITLE
misc

### DIFF
--- a/walkers/src/mvt.rs
+++ b/walkers/src/mvt.rs
@@ -169,11 +169,8 @@ pub fn transformed(shapes: &[ShapeOrText], rect: egui::Rect) -> Vec<ShapeOrText>
     result
 }
 
-fn get_layer_features(
-    reader: &Reader,
-    name: &str,
-) -> Result<Vec<Feature>, mvt_reader::error::ParserError> {
-    if let Ok(layer_index) = find_layer(&reader, name) {
+fn get_layer_features(reader: &Reader, name: &str) -> Result<Vec<Feature>, Error> {
+    if let Ok(layer_index) = find_layer(reader, name) {
         Ok(reader.get_features(layer_index)?)
     } else {
         warn!("Source layer '{name}' not found. Skipping.");


### PR DESCRIPTION
 * [ ] Map is displaying and reacting to input correctly, both natively and on the web.
 * [ ] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
