### PR TITLE
Some small modules extracted

### DIFF
--- a/walkers/src/lib.rs
+++ b/walkers/src/lib.rs
@@ -7,6 +7,7 @@ mod io;
 mod local_tiles;
 mod map;
 mod memory;
+mod options;
 mod plugin;
 #[cfg(feature = "mvt")]
 mod style;
@@ -41,6 +42,7 @@ pub use io::{HeaderValue, MaxParallelDownloads, http::HttpOptions};
 pub use local_tiles::LocalTiles;
 pub use map::Map;
 pub use memory::MapMemory;
+pub use options::Options;
 pub use plugin::Plugin;
 #[cfg(feature = "pmtiles")]
 pub use pmtiles::PmTiles;

--- a/walkers/src/lib.rs
+++ b/walkers/src/lib.rs
@@ -7,6 +7,7 @@ mod io;
 mod local_tiles;
 mod map;
 mod memory;
+mod plugin;
 #[cfg(feature = "mvt")]
 mod style;
 #[cfg(feature = "mvt")]
@@ -38,8 +39,9 @@ pub use http_tiles::HttpTiles;
 pub use io::tiles_io::Stats;
 pub use io::{HeaderValue, MaxParallelDownloads, http::HttpOptions};
 pub use local_tiles::LocalTiles;
-pub use map::{Map, Plugin};
+pub use map::Map;
 pub use memory::MapMemory;
+pub use plugin::Plugin;
 #[cfg(feature = "pmtiles")]
 pub use pmtiles::PmTiles;
 pub use position::{Position, lat_lon, lon_lat};

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -3,39 +3,13 @@ use egui::{
 };
 
 use crate::{
-    MapMemory, Plugin, Position, Projector, Tiles, center::Center, position::AdjustedPosition,
-    tiles::draw_tiles,
+    MapMemory, Options, Plugin, Position, Projector, Tiles, center::Center,
+    position::AdjustedPosition, tiles::draw_tiles,
 };
 
 struct Layer<'a> {
     tiles: &'a mut dyn Tiles,
     transparency: f32,
-}
-
-struct Options {
-    zoom_gesture_enabled: bool,
-    drag_pan_buttons: DragPanButtons,
-    zoom_speed: f64,
-    double_click_to_zoom: bool,
-    double_click_to_zoom_out: bool,
-    zoom_with_ctrl: bool,
-    panning: bool,
-    pull_to_my_position_threshold: f32,
-}
-
-impl Default for Options {
-    fn default() -> Self {
-        Self {
-            zoom_gesture_enabled: true,
-            drag_pan_buttons: DragPanButtons::PRIMARY,
-            zoom_speed: 2.0,
-            double_click_to_zoom: false,
-            double_click_to_zoom_out: false,
-            zoom_with_ctrl: true,
-            panning: true,
-            pull_to_my_position_threshold: 0.0,
-        }
-    }
 }
 
 /// The actual map widget. Instances are to be created on each frame, as all necessary state is

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -3,30 +3,9 @@ use egui::{
 };
 
 use crate::{
-    MapMemory, Position, Projector, Tiles, center::Center, position::AdjustedPosition,
+    MapMemory, Plugin, Position, Projector, Tiles, center::Center, position::AdjustedPosition,
     tiles::draw_tiles,
 };
-
-/// Plugins allow drawing custom shapes on the map. After implementing this trait for your type,
-/// you can add it to the map with [`Map::with_plugin`]
-pub trait Plugin {
-    /// Function called at each frame.
-    ///
-    /// The provided [`Ui`] has its [`Ui::max_rect`] set to the full rect that was allocated
-    /// by the map widget. Implementations should typically use the provided [`Projector`] to
-    /// compute target screen coordinates and use one of the various egui methods to draw at these
-    /// coordinates instead of relying on [`Ui`] layout system.
-    ///
-    /// The provided [`Response`] is the response of the map widget itself and can be used to test
-    /// if the mouse is hovering or clicking on the map.
-    fn run(
-        self: Box<Self>,
-        ui: &mut Ui,
-        response: &Response,
-        projector: &Projector,
-        map_memory: &MapMemory,
-    );
-}
 
 struct Layer<'a> {
     tiles: &'a mut dyn Tiles,

--- a/walkers/src/options.rs
+++ b/walkers/src/options.rs
@@ -1,0 +1,27 @@
+use egui::DragPanButtons;
+
+pub struct Options {
+    pub zoom_gesture_enabled: bool,
+    pub drag_pan_buttons: DragPanButtons,
+    pub zoom_speed: f64,
+    pub double_click_to_zoom: bool,
+    pub double_click_to_zoom_out: bool,
+    pub zoom_with_ctrl: bool,
+    pub panning: bool,
+    pub pull_to_my_position_threshold: f32,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            zoom_gesture_enabled: true,
+            drag_pan_buttons: DragPanButtons::PRIMARY,
+            zoom_speed: 2.0,
+            double_click_to_zoom: false,
+            double_click_to_zoom_out: false,
+            zoom_with_ctrl: true,
+            panning: true,
+            pull_to_my_position_threshold: 0.0,
+        }
+    }
+}

--- a/walkers/src/plugin.rs
+++ b/walkers/src/plugin.rs
@@ -3,7 +3,7 @@ use egui::{Response, Ui};
 use crate::{MapMemory, Projector};
 
 /// Plugins allow drawing custom shapes on the map. After implementing this trait for your type,
-/// you can add it to the map with [`Map::with_plugin`]
+/// you can add it to the map with [`crate::Map::with_plugin`]
 pub trait Plugin {
     /// Function called at each frame.
     ///

--- a/walkers/src/plugin.rs
+++ b/walkers/src/plugin.rs
@@ -1,0 +1,24 @@
+use egui::{Response, Ui};
+
+use crate::{MapMemory, Projector};
+
+/// Plugins allow drawing custom shapes on the map. After implementing this trait for your type,
+/// you can add it to the map with [`Map::with_plugin`]
+pub trait Plugin {
+    /// Function called at each frame.
+    ///
+    /// The provided [`Ui`] has its [`Ui::max_rect`] set to the full rect that was allocated
+    /// by the map widget. Implementations should typically use the provided [`Projector`] to
+    /// compute target screen coordinates and use one of the various egui methods to draw at these
+    /// coordinates instead of relying on [`Ui`] layout system.
+    ///
+    /// The provided [`Response`] is the response of the map widget itself and can be used to test
+    /// if the mouse is hovering or clicking on the map.
+    fn run(
+        self: Box<Self>,
+        ui: &mut Ui,
+        response: &Response,
+        projector: &Projector,
+        map_memory: &MapMemory,
+    );
+}

--- a/walkers/src/style.rs
+++ b/walkers/src/style.rs
@@ -9,7 +9,7 @@ use crate::expression::Context;
 
 /// Style for rendering vector maps.
 ///
-/// It is beased on MapLibre's style specification, but only a small subset is supported.
+/// It is based on MapLibre's style specification, but only a small subset is supported.
 /// Most notably, Walkers only read `layers` section of the style and applies it to the
 /// [`crate::Tiles`] it is used with. In spite that, it should be possible to deserialize most
 /// of the MapLibre's styles using `serde`, as unknown JSON/YAML fields are simply ignored.


### PR DESCRIPTION
 * [ ] Map is displaying and reacting to input correctly, both natively and on the web.
 * [ ] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
