### PR TITLE
Decompress using internal `pmtiles` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+ * Use `pmtiles` internal decompression handling instead of hand-rolled one.
+
 ## 0.54.0
 
  * Experimental support for `geojson` with very limited capabilities.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5434,7 +5434,6 @@ dependencies = [
  "egui",
  "egui_extras",
  "env_logger",
- "flate2",
  "futures",
  "geo",
  "geo-types",

--- a/walkers/Cargo.toml
+++ b/walkers/Cargo.toml
@@ -14,7 +14,6 @@ bytes = "1"
 color = { version = "0.3.2", features = ["serde"], optional = true }
 egui.workspace = true
 egui_extras.workspace = true
-flate2 = { version = "1.1.8", optional = true }
 futures = "0.3.32"
 geo = { version = "0.33.1", default-features = false, optional = true }
 geo-types = { version = "0.7" }
@@ -63,5 +62,5 @@ mvt = [
   "dep:serde",
   "dep:serde_json"
 ]
-pmtiles = ["dep:flate2", "dep:pmtiles"]
+pmtiles = ["dep:pmtiles"]
 serde = ["dep:serde", "egui/serde", "geo-types/serde"]

--- a/walkers/src/pmtiles.rs
+++ b/walkers/src/pmtiles.rs
@@ -128,11 +128,11 @@ impl Fetch for PmTilesFetch {
         // TODO: Avoid reopening the file every time.
         let reader = AsyncPmTilesReader::new_with_path(self.path.to_owned()).await?;
         let bytes = reader
-            .get_tile(TileCoord::new(tile_id.zoom, tile_id.x, tile_id.y)?)
+            .get_tile_decompressed(TileCoord::new(tile_id.zoom, tile_id.x, tile_id.y)?)
             .await?
             .ok_or(PmTilesError::TileNotFound(tile_id))?;
 
-        Ok(decompress(&bytes)?.into())
+        Ok(bytes.into())
     }
 
     fn max_concurrency(&self) -> usize {

--- a/walkers/src/pmtiles.rs
+++ b/walkers/src/pmtiles.rs
@@ -127,12 +127,11 @@ impl Fetch for PmTilesFetch {
     async fn fetch(&self, tile_id: TileId) -> Result<Bytes, Self::Error> {
         // TODO: Avoid reopening the file every time.
         let reader = AsyncPmTilesReader::new_with_path(self.path.to_owned()).await?;
-        let bytes = reader
+
+        Ok(reader
             .get_tile_decompressed(TileCoord::new(tile_id.zoom, tile_id.x, tile_id.y)?)
             .await?
-            .ok_or(PmTilesError::TileNotFound(tile_id))?;
-
-        Ok(bytes.into())
+            .ok_or(PmTilesError::TileNotFound(tile_id))?)
     }
 
     fn max_concurrency(&self) -> usize {

--- a/walkers/src/pmtiles.rs
+++ b/walkers/src/pmtiles.rs
@@ -9,7 +9,7 @@ use bytes::Bytes;
 use egui::Context;
 use pmtiles::{AsyncPmTilesReader, TileCoord};
 use std::{
-    io::{self, Read as _},
+    io::{self},
     path::{Path, PathBuf},
 };
 use thiserror::Error;
@@ -141,15 +141,4 @@ impl Fetch for PmTilesFetch {
         // follow this value as well.
         6
     }
-}
-
-/// Decompress the tile.
-///
-/// This function assumes the input is gzip compressed data, but this might not always be the case.
-/// You can use `pmtiles info <file>` to check the compression type.
-fn decompress(data: &[u8]) -> io::Result<Vec<u8>> {
-    let mut decoder = flate2::read::GzDecoder::new(data);
-    let mut buf = Vec::new();
-    decoder.read_to_end(&mut buf)?;
-    Ok(buf)
 }


### PR DESCRIPTION
 * [ ] Map is displaying and reacting to input correctly, both natively and on the web.
 * [ ] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
