### PR TITLE
Zoom overshoot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
  * Use `pmtiles` internal decompression handling instead of hand-rolled one.
+ * Fix scroll zoom overshooting on slow frames when `zoom_with_ctrl` is disabled.
 
 ## 0.54.0
 

--- a/walkers/src/map.rs
+++ b/walkers/src/map.rs
@@ -278,7 +278,10 @@ impl Map<'_, '_, '_> {
             // These values seem to correspond to the same values as one would get in `zoom_delta()`
             zoom_delta = 1f64
                 + ui.input(|input| {
-                    input.smooth_scroll_delta.y * input.stable_dt.max(input.predicted_dt * 1.5)
+                    input.smooth_scroll_delta.y
+                        * input
+                            .stable_dt
+                            .clamp(input.predicted_dt * 0.5, input.predicted_dt * 2.0)
                 }) as f64
                     / 4.0;
         };


### PR DESCRIPTION
 * [ ] Map is displaying and reacting to input correctly, both natively and on the web.
 * [ ] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
