### PR TITLE
empty layer matches all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* An empty `source_layer` now matches features from all layers of a vector tile.
+
 ## 0.56.0
 
 * `egui` updated to 0.35.

--- a/walkers/src/mvt.rs
+++ b/walkers/src/mvt.rs
@@ -196,9 +196,7 @@ fn get_layer_features(
         Vec::new()
     };
 
-    let features = raw
-        .into_iter()
-        .filter_map(move |feature| {
+    let features = raw.into_iter().filter_map(move |feature| {
         let context = Context::new(
             geometry_type_to_str(&feature.geometry).to_string(),
             feature

--- a/walkers/src/mvt.rs
+++ b/walkers/src/mvt.rs
@@ -180,14 +180,25 @@ fn get_layer_features(
     name: &str,
     filter: Option<&Filter>,
 ) -> Result<impl Iterator<Item = (Geometry<f32>, Context)>, Error> {
-    let features = if let Ok(layer_index) = find_layer(reader, name) {
+    // An empty source layer matches features from all layers. Intended for sparse
+    // overlay tiles; pointing dense basemap rules at "" would scan every layer.
+    let raw = if name.is_empty() {
+        reader
+            .get_layer_metadata()?
+            .into_iter()
+            .filter(|layer| layer.extent == ONLY_SUPPORTED_EXTENT)
+            .flat_map(|layer| reader.get_features(layer.layer_index).unwrap_or_default())
+            .collect()
+    } else if let Ok(layer_index) = find_layer(reader, name) {
         reader.get_features(layer_index)?
     } else {
         warn!("Source layer '{name}' not found. Skipping.");
         Vec::new()
-    }
-    .into_iter()
-    .filter_map(move |feature| {
+    };
+
+    let features = raw
+        .into_iter()
+        .filter_map(move |feature| {
         let context = Context::new(
             geometry_type_to_str(&feature.geometry).to_string(),
             feature


### PR DESCRIPTION
 * [ ] Map is displaying and reacting to input correctly, both natively and on the web.
 * [ ] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
