### PR TITLE
Fix panic on zoom out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 * An empty `source_layer` now matches features from all layers of a vector tile.
+* Fix crash when zooming out close to zoom 0 with tile sources serving tiles larger than 256px.
 
 ## 0.56.0
 

--- a/walkers/src/mercator.rs
+++ b/walkers/src/mercator.rs
@@ -26,7 +26,7 @@ pub(crate) fn total_tiles(zoom: u8) -> u32 {
 }
 
 /// Size of a single tile in pixels. Walkers uses 256px tiles as most of the tile sources do.
-const TILE_SIZE: u32 = 256;
+pub(crate) const TILE_SIZE: u32 = 256;
 
 /// Project the position into the Mercator projection and normalize it to 0-1 range.
 fn mercator_normalized(position: Position) -> (f64, f64) {
@@ -42,12 +42,13 @@ fn mercator_normalized(position: Position) -> (f64, f64) {
 }
 
 /// Calculate the tile coordinated for the given position.
-pub(crate) fn tile_id(position: Position, mut zoom: u8, source_tile_size: u32) -> TileId {
+pub(crate) fn tile_id(position: Position, zoom: u8, source_tile_size: u32) -> TileId {
     let (x, y) = mercator_normalized(position);
 
     // Some sources provide larger tiles, effectively bundling e.g. 4 256px tiles in one
     // 512px one. Walkers uses 256px internally, so we need to adjust the zoom level.
-    zoom -= (source_tile_size as f64 / TILE_SIZE as f64).log2() as u8;
+    // Saturate, since there is nothing below the single tile covering the whole world.
+    let zoom = zoom.saturating_sub((source_tile_size as f64 / TILE_SIZE as f64).log2() as u8);
 
     // Map that into a big bitmap made out of web tiles.
     let number_of_tiles = 2u32.pow(zoom as u32) as f64;
@@ -125,6 +126,30 @@ mod tests {
         let citadel_proj = Pixels::new(585455. * 256. + 184., 345104. * 256. + 116.5);
         approx::assert_relative_eq!(calculated.x(), citadel_proj.x(), max_relative = 0.5);
         approx::assert_relative_eq!(calculated.y(), citadel_proj.y(), max_relative = 0.5);
+    }
+
+    #[test]
+    fn zoomed_out_further_than_source_tile_size_allows() {
+        let citadel = lon_lat(21.00027, 52.26470);
+
+        // Large tiles mean lower zoom levels, but there is nothing below the single tile
+        // covering the whole world.
+        assert_eq!(
+            TileId {
+                x: 0,
+                y: 0,
+                zoom: 0
+            },
+            tile_id(citadel, 0, 512)
+        );
+        assert_eq!(
+            TileId {
+                x: 0,
+                y: 0,
+                zoom: 0
+            },
+            tile_id(citadel, 1, 1024)
+        );
     }
 
     #[test]

--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -15,7 +15,7 @@ use thiserror::Error;
 
 use crate::Position;
 use crate::io::TileFactory;
-use crate::mercator::{project, tile_id, total_tiles};
+use crate::mercator::{TILE_SIZE, project, tile_id, total_tiles};
 use crate::position::{Pixels, PixelsExt};
 use crate::sources::Attribution;
 use crate::style::Style;
@@ -270,8 +270,10 @@ fn flood_fill_tiles(
     transparency: f32,
     meshes: &mut HashSet<TileId>,
 ) {
-    // We need to make up the difference between integer and floating point zoom levels.
-    let corrected_tile_size = tiles.tile_size() as f64 * 2f64.powf(zoom - zoom.round());
+    // The tile's zoom level can differ from the map's: it is rounded to an integer, adjusted
+    // for sources with tiles larger than 256px, and clamped at 0. Scale the tile so that it
+    // covers the right amount of the map regardless.
+    let corrected_tile_size = TILE_SIZE as f64 * 2f64.powf(zoom - tile_id.zoom as f64);
     let tile_projected = tile_id.project(corrected_tile_size);
     let tile_screen_position = painter.clip_rect().center().to_vec2()
         + (tile_projected - map_center_projected_position).to_vec2();


### PR DESCRIPTION
 * [ ] Map is displaying and reacting to input correctly, both natively and on the web.
 * [ ] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
