### PR TITLE
Pub text field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 * An empty `source_layer` now matches features from all layers of a vector tile.
 * Fix crash when zooming out close to zoom 0 with tile sources serving tiles larger than 256px.
 * Support `line-dasharray` in vector tile styles.
+* `Layout::text_field` is now public.
 
 ## 0.56.0
 

--- a/walkers/src/style.rs
+++ b/walkers/src/style.rs
@@ -216,7 +216,7 @@ impl Filter {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Layout {
-    text_field: Option<Value>,
+    pub text_field: Option<Value>,
     pub text_size: Option<Float>,
 }
 


### PR DESCRIPTION
 * [ ] Map is displaying and reacting to input correctly, both natively and on the web.
 * [ ] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
