### PR TITLE
pub some types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 * An empty `source_layer` now matches features from all layers of a vector tile.
 * Fix crash when zooming out close to zoom 0 with tile sources serving tiles larger than 256px.
 * Support `line-dasharray` in vector tile styles.
-* `Layout::text_field` is now public.
+* `Layer`, `Dasharray`, and `Layout::text_field` are now public.
 
 ## 0.56.0
 

--- a/walkers/src/lib.rs
+++ b/walkers/src/lib.rs
@@ -50,7 +50,7 @@ pub use position::{Position, lat_lon, lon_lat};
 pub use projector::Projector;
 pub use style::Style;
 #[cfg(feature = "mvt")]
-pub use style::{Color, Filter, Float, Layer, Paint, Value, json};
+pub use style::{Color, Dasharray, Filter, Float, Layer, Paint, Value, json};
 pub use tiles::{Tile, TileId, TilePiece, Tiles};
 pub use zoom::InvalidZoom;
 


### PR DESCRIPTION
 * [ ] Map is displaying and reacting to input correctly, both natively and on the web.
 * [ ] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
