### PR TITLE
Support tile sources with tiles smaller than 256px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+* Fix tile sources with tiles smaller than 256px being rendered as if they were 256px.
+
 ## 0.58.0
 
 * `egui` updated to 0.36.

--- a/walkers/src/mercator.rs
+++ b/walkers/src/mercator.rs
@@ -28,6 +28,16 @@ pub(crate) fn total_tiles(zoom: u8) -> u32 {
 /// Size of a single tile in pixels. Walkers uses 256px tiles as most of the tile sources do.
 pub(crate) const TILE_SIZE: u32 = 256;
 
+/// Highest zoom level a [`TileId`] can have. Above this, the number of tiles no longer fits
+/// in the `u32` used for the tile coordinates.
+const MAX_TILE_ZOOM: u8 = 31;
+
+/// How many zoom levels a source with `source_tile_size` tiles is off from the 256px grid
+/// Walkers uses internally. Positive for larger tiles, negative for smaller ones.
+fn zoom_offset(source_tile_size: u32) -> i32 {
+    (source_tile_size as f64 / TILE_SIZE as f64).log2().round() as i32
+}
+
 /// Project the position into the Mercator projection and normalize it to 0-1 range.
 fn mercator_normalized(position: Position) -> (f64, f64) {
     // Project into Mercator (cylindrical map projection).
@@ -45,10 +55,14 @@ fn mercator_normalized(position: Position) -> (f64, f64) {
 pub(crate) fn tile_id(position: Position, zoom: u8, source_tile_size: u32) -> TileId {
     let (x, y) = mercator_normalized(position);
 
-    // Some sources provide larger tiles, effectively bundling e.g. 4 256px tiles in one
-    // 512px one. Walkers uses 256px internally, so we need to adjust the zoom level.
-    // Saturate, since there is nothing below the single tile covering the whole world.
-    let zoom = zoom.saturating_sub((source_tile_size as f64 / TILE_SIZE as f64).log2() as u8);
+    // Some sources provide tiles of a different size, effectively bundling e.g. 4 256px tiles
+    // in one 512px one, or splitting a single one into 4 128px ones. Walkers uses 256px
+    // internally, so we need to adjust the zoom level in either direction.
+    let zoom = (zoom as i32).saturating_sub(zoom_offset(source_tile_size));
+
+    // Clamp, since there is nothing below the single tile covering the whole world, and going
+    // too far up would overflow the number of tiles.
+    let zoom = zoom.clamp(0, MAX_TILE_ZOOM as i32) as u8;
 
     // Map that into a big bitmap made out of web tiles.
     let number_of_tiles = 2u32.pow(zoom as u32) as f64;
@@ -126,6 +140,50 @@ mod tests {
         let citadel_proj = Pixels::new(585455. * 256. + 184., 345104. * 256. + 116.5);
         approx::assert_relative_eq!(calculated.x(), citadel_proj.x(), max_relative = 0.5);
         approx::assert_relative_eq!(calculated.y(), citadel_proj.y(), max_relative = 0.5);
+    }
+
+    /// Tiles smaller than 256px need *more* tiles to cover the same area, which means going
+    /// one zoom level deeper for every halving of the tile size.
+    /// See: <https://github.com/podusowski/walkers/issues/551>
+    #[test]
+    fn smaller_tiles_zoom_in() {
+        let citadel = lon_lat(21.00027, 52.26470);
+        let zoom = 20;
+
+        // The citadel is at 184x116 of its 256px tile, so it falls into the right-top
+        // quadrant once that tile is split into four 128px ones.
+        assert_eq!(
+            TileId {
+                x: 585455 * 2 + 1,
+                y: 345104 * 2,
+                zoom: zoom + 1
+            },
+            tile_id(citadel, zoom, 128)
+        );
+
+        // Whatever the tile size, the smaller tile has to lie within the 256px one covering
+        // the same position.
+        for (tile_size, levels) in [(128, 1), (64, 2), (32, 3)] {
+            let base = tile_id(citadel, zoom, 256);
+            let smaller = tile_id(citadel, zoom, tile_size);
+            let ratio = 2u32.pow(levels);
+
+            assert_eq!(base.zoom + levels as u8, smaller.zoom);
+            assert_eq!(base.x, smaller.x / ratio);
+            assert_eq!(base.y, smaller.y / ratio);
+        }
+    }
+
+    /// Number of tiles is kept in `u32`, so the zoom level cannot grow indefinitely, no matter
+    /// how small the tiles of a source are.
+    #[test]
+    fn zoomed_in_further_than_tile_coordinates_allow() {
+        let citadel = lon_lat(21.00027, 52.26470);
+
+        assert_eq!(MAX_TILE_ZOOM, tile_id(citadel, 26, 1).zoom);
+
+        // Degenerate, but it should not panic either.
+        assert_eq!(MAX_TILE_ZOOM, tile_id(citadel, 26, 0).zoom);
     }
 
     #[test]

--- a/walkers/src/sources/mod.rs
+++ b/walkers/src/sources/mod.rs
@@ -26,7 +26,8 @@ pub trait TileSource {
     fn tile_url(&self, tile_id: TileId) -> String;
     fn attribution(&self) -> Attribution;
 
-    /// Size of each tile, should be a multiple of 256.
+    /// Size of each tile, in pixels. Walkers works with 256px tiles internally, so this
+    /// should be 256 multiplied or divided by a power of two, for example 128, 256 or 512.
     fn tile_size(&self) -> u32 {
         256
     }

--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -102,6 +102,9 @@ impl TileId {
 pub trait Tiles {
     fn at(&mut self, tile_id: TileId) -> Option<TilePiece>;
     fn attribution(&self) -> Attribution;
+
+    /// Size of each tile, in pixels. Walkers works with 256px tiles internally, so this
+    /// should be 256 multiplied or divided by a power of two, for example 128, 256 or 512.
     fn tile_size(&self) -> u32;
 }
 
@@ -381,6 +384,91 @@ impl TileFactory for EguiTileFactory {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lon_lat;
+
+    /// Records which tiles were asked for, without ever returning one.
+    struct RecordingTiles {
+        tile_size: u32,
+        requested: Vec<TileId>,
+    }
+
+    impl RecordingTiles {
+        fn new(tile_size: u32) -> Self {
+            Self {
+                tile_size,
+                requested: Vec::new(),
+            }
+        }
+    }
+
+    impl Tiles for RecordingTiles {
+        fn at(&mut self, tile_id: TileId) -> Option<TilePiece> {
+            self.requested.push(tile_id);
+            None
+        }
+
+        fn attribution(&self) -> Attribution {
+            Attribution {
+                text: "",
+                url: "",
+                logo_light: None,
+                logo_dark: None,
+            }
+        }
+
+        fn tile_size(&self) -> u32 {
+            self.tile_size
+        }
+    }
+
+    /// Run [`draw_tiles`] on a viewport of `TILE_SIZE` squared, and report which tiles the
+    /// source was asked for.
+    fn requested_tiles(tile_size: u32, zoom: f64) -> Vec<TileId> {
+        let ctx = Context::default();
+        let painter = egui::Painter::new(
+            ctx,
+            egui::LayerId::debug(),
+            Rect::from_min_size(pos2(0., 0.), Vec2::splat(TILE_SIZE as f32)),
+        );
+
+        let mut tiles = RecordingTiles::new(tile_size);
+
+        #[allow(clippy::unwrap_used)]
+        draw_tiles(
+            &painter,
+            lon_lat(21.00027, 52.26470),
+            Zoom::try_from(zoom).unwrap(),
+            &mut tiles,
+            1.0,
+        );
+
+        tiles.requested
+    }
+
+    /// Sources with tiles smaller than 256px are just as valid as the larger ones, and the
+    /// map should not go blank when one is used.
+    /// See: <https://github.com/podusowski/walkers/issues/551>
+    #[test]
+    fn smaller_tiles_are_requested_from_a_higher_zoom_level() {
+        let zoom = 16.;
+
+        // A 256px source covers the viewport with tiles from the map's own zoom level.
+        let with_256 = requested_tiles(256, zoom);
+        assert!(!with_256.is_empty());
+        assert!(with_256.iter().all(|tile_id| tile_id.zoom == 16));
+
+        // 128px tiles are half the size, so they have to come from one zoom level deeper to
+        // show the same area at the same scale, and more of them are needed to fill the
+        // viewport.
+        let with_128 = requested_tiles(128, zoom);
+        assert!(with_128.iter().all(|tile_id| tile_id.zoom == 17));
+        assert!(with_128.len() > with_256.len());
+
+        // Same story one step further down.
+        let with_64 = requested_tiles(64, zoom);
+        assert!(with_64.iter().all(|tile_id| tile_id.zoom == 18));
+        assert!(with_64.len() > with_128.len());
+    }
 
     #[test]
     fn test_full_rect_of_clipped_tile() {


### PR DESCRIPTION
Fixes #551.

## The bug

`tile_id` normalized a source's tile grid onto the 256px one Walkers uses internally with:

```rust
zoom.saturating_sub((source_tile_size as f64 / TILE_SIZE as f64).log2() as u8)
```

For a 128px source the inner expression is `log2(0.5)` = `-1.0`, and Rust's float-to-integer casts saturate, so `-1.0 as u8` is **0**. The adjustment silently vanished — the scheme only ever worked in the "tiles larger than 256px" direction. Sub-256 sources were treated exactly like 256px ones: tiles were requested one (or more) zoom levels too shallow and then stretched over twice the area they should cover.

## The fix

Compute the offset as a signed `i32` so it can go negative (smaller tiles ⇒ *deeper* zoom), then clamp. The lower bound stays 0 — there is nothing below the single tile covering the whole world — and a new upper bound keeps the tile count inside the `u32` used for tile coordinates, since `2u32.pow(32)` would overflow. The subtraction is saturating so a degenerate `tile_size` of 0 (`log2` → `-inf`) cannot overflow either.

`flood_fill_tiles` needed no change: it derives the drawn size from the actual `tile_id.zoom` rather than assuming the offset applied, which is what already made it survive the zoom-0 clamp fixed in 0.57.0, and it handles the new upper clamp for the same reason.

## On the reported symptom

I drove `draw_tiles` with a recording `Tiles` impl and could **not** reproduce "no `Tiles.at` will be called" — `at` was called for every visible tile, just with tile IDs at the wrong zoom. The black screen is most likely the reporter's own `at` returning `None` for those wrong IDs, which this resolves. Worth confirming with them.

Note that `HttpTiles::at` compares `tile_id.zoom` against the source's `max_zoom` in the normalized 256px grid, so a 128px source declaring `max_zoom` 19 now effectively tops out at map zoom 18 and interpolates above that. That is consistent with how 512px sources already behave, so it is left as is.

## Tests

- `tiles::smaller_tiles_are_requested_from_a_higher_zoom_level` — end-to-end through `draw_tiles`; fails on `main`.
- `mercator::smaller_tiles_zoom_in` — tile ID math for 128/64/32px, including that a smaller tile always lies within the 256px tile covering the same position.
- `mercator::zoomed_in_further_than_tile_coordinates_allow` — the new upper clamp, including the degenerate zero size.

Docs on both `TileSource::tile_size` and `Tiles::tile_size` are corrected; the former said "should be a multiple of 256", which is what made sub-256 sizes look unsupported by design.

`just check` and `just lints` are clean, 54 tests plus 2 doctests pass. `just typos` was not run — the `typos` binary is not installed on my machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)