### PR TITLE
Remove the now-redundant explicit `wgpu` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,7 +989,6 @@ dependencies = [
  "rand 0.10.2",
  "walkers",
  "walkers_extras",
- "wgpu",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,6 @@ walkers = { path = "walkers", version = "0.58.0" }
 walkers_extras = { path = "walkers_extras", version = "0.58.0" }
 wasm-bindgen-futures = "0.4.76"
 web-sys = "0.3.103"
-wgpu = { version = "30.0", default-features = true } # Aligned to the `wgpu` version that egui 0.36 uses
 
 # [patch.crates-io]
 # eframe = { git = "https://github.com/emilk/egui.git", branch = "main" }

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -11,7 +11,6 @@ eframe.workspace = true
 egui.workspace = true
 egui_extras.workspace = true
 rand.workspace = true
-wgpu.workspace = true
 
 [features]
 default = []


### PR DESCRIPTION
`demo` gained a direct `wgpu = { default-features = true }` dependency in 2edef21 as a workaround for emilk/egui#7344 — the commit message even said *"This is needed until #7344 is released."* Back then `egui-wgpu` pulled `wgpu` with `default-features = false, features = ["std", "wgsl"]`, and nothing turned the graphics backends back on, so an app ended up with a `wgpu` that had no vulkan/metal/dx12/gles and found no adapter. The direct dependency re-enabled them through feature unification. No code ever used the crate — it was purely a feature switch.

Later, b4e96e2 moved it to the workspace table and dropped the explanatory comment, so all that remained was a version-alignment note that had to be maintained on every egui bump.

Since #7344 landed, the chain is fixed upstream:

- `eframe`'s `default` includes `wgpu`
- `eframe/wgpu` → `egui-wgpu/default`
- `egui-wgpu/default` → `wgpu/default` + `wgpu/webgl`

## Verification

`cargo tree -e features` resolves `wgpu` to a byte-identical feature set before and after, for both `demo_native` and `demo_android`:

```
default,dx12,fragile-send-sync-non-atomic-wasm,gles,metal,parking_lot,std,vulkan,web,webgl,webgpu,wgpu-core,wgsl
```

The only graph change is one fewer edge — `wgpu/default` is now enabled solely via `egui-wgpu/default` instead of via that plus the direct `demo` dependency. `Cargo.lock` loses exactly one line (`wgpu` under `demo`); the `wgpu` package itself stays, since `egui-wgpu` still needs it.

Checks run locally, all green:

- `just check-lean`, `just check-all-features`, `just check-demo`
- `cargo test` — 68 passed, 0 failed
- `just lints` (fmt, clippy `-D warnings`, doc)
- `cargo check -p demo_web --target wasm32-unknown-unknown` — `wgpu-core-deps-wasm` still compiles, so the web backends are intact
- `cargo ndk --target arm64-v8a check` on `demo_android` — `wgpu-core-deps-windows-linux-android` still compiles, so the vulkan/gles backends are intact

No changelog entry: this touches only the unpublished `demo` crate's build, not `walkers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)