### PR TITLE
Render symbol layers in `GeoJsonLayer`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@
 
 .DS_Store
 *.pmtiles
+
+# Downloaded by the `overpass-*` recipes, and picked up by the demo.
+/*.geojson
+/*.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 * Fix tile sources with tiles smaller than 256px being rendered as if they were 256px.
+* `GeoJsonLayer` now renders `symbol` layers, including their text labels.
 
 ## 0.58.0
 

--- a/Justfile
+++ b/Justfile
@@ -49,6 +49,14 @@ overpass-trails-dolnoslaskie:
         -o trails.json
     osmtogeojson trails.json > trails.geojson
 
+# Download mountain peaks for Dolnośląskie, Poland from OpenStreetMap using Overpass API and convert to GeoJSON
+[group('data')]
+overpass-peaks-dolnoslaskie:
+    curl -G https://overpass-api.de/api/interpreter \
+        --data-urlencode 'data=[out:json][timeout:120];(node["natural"="peak"]["name"]({{ DOLNOSLASKIE_OVERPASS_BBOX }}););out geom;' \
+        -o peaks.json
+    osmtogeojson peaks.json > peaks.geojson
+
 # Download the latest PMTiles file for Dolnośląskie, Poland from Protomaps.
 [group('data')]
 protomaps-dolnoslaskie:

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -8,7 +8,7 @@ use std::io;
 
 use egui::{Button, Context, DragPanButtons, OpenUrl, Rect, Vec2};
 use tiles::{TilesKind, providers};
-use walkers::{Color, Filter, Float, Layer, Map, MapMemory, Paint, Style, json};
+use walkers::{Color, Filter, Float, Layer, Layout, Map, MapMemory, Paint, Style, json};
 use walkers_extras::GeoJsonLayer;
 
 use crate::tiles::Providers;
@@ -132,14 +132,16 @@ fn geojson_layers() -> Result<Vec<GeoJsonLayer>, io::Error> {
         if path.extension().and_then(|s| s.to_str()) == Some("geojson") {
             let content = fs::read_to_string(path)?;
             let geojson = content.parse().unwrap();
-            layers.push(GeoJsonLayer::new(geojson, trails_style()));
+            layers.push(GeoJsonLayer::new(geojson, hiking_style()));
         }
     }
 
     Ok(layers)
 }
 
-fn trails_style() -> Style {
+/// One style for every `.geojson` found, with filters picking what each layer applies to.
+/// See `just overpass-trails-dolnoslaskie` and `just overpass-peaks-dolnoslaskie`.
+fn hiking_style() -> Style {
     let width = |factor| {
         Float(json!([
             "interpolate",
@@ -225,6 +227,26 @@ fn trails_style() -> Style {
                     line_width: Some(width(0.2)),
                     ..Default::default()
                 },
+            },
+            Layer::Symbol {
+                source_layer: "".to_string(),
+                filter: Some(Filter(json!(["==", ["get", "natural"], "peak"]))),
+                layout: Layout {
+                    text_field: Some(json!(["get", "name"])),
+                    text_size: Some(Float(json!([
+                        "interpolate",
+                        ["linear"],
+                        ["zoom"],
+                        8.0,
+                        9.0,
+                        16.0,
+                        16.0
+                    ]))),
+                },
+                paint: Some(Paint {
+                    text_color: Some(Color(json!("#3d2b1f"))),
+                    ..Default::default()
+                }),
             },
         ],
     }

--- a/walkers/src/lib.rs
+++ b/walkers/src/lib.rs
@@ -58,4 +58,6 @@ pub use zoom::InvalidZoom;
 #[cfg(feature = "mvt")]
 pub use expression::Context;
 #[cfg(feature = "mvt")]
-pub use mvt::{Geometry, ShapeOrText, render_line, tessellate_polygon};
+pub use mvt::{
+    Geometry, ShapeOrText, render_line, render_symbol, resolve_text, tessellate_polygon,
+};

--- a/walkers/src/mvt.rs
+++ b/walkers/src/mvt.rs
@@ -23,7 +23,7 @@ use serde_json::{Number, Value as JsonValue};
 use crate::{
     expression::Context,
     style::{Filter, Layer, Layout, Paint, Style},
-    text::Text,
+    text::{OccupiedAreas, OrientedRect, Text},
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -172,6 +172,50 @@ pub fn transformed(shapes: &[ShapeOrText], rect: egui::Rect) -> Vec<ShapeOrText>
         shape.transform(transform);
     }
     result
+}
+
+/// Lay out the labels, dropping the ones which would land on top of an already placed one.
+pub fn resolve_text(shapes: Vec<ShapeOrText>, ctx: &egui::Context) -> Vec<Shape> {
+    let mut occupied_text_areas = OccupiedAreas::new();
+
+    // Need to collect it to avoid deadlock caused by `Painter::extend` and `fonts_mut`.
+    shapes
+        .into_iter()
+        .map(|shape_or_text| match shape_or_text {
+            ShapeOrText::Shape(shape) => shape,
+            ShapeOrText::Text(text) => draw_text(text, ctx, &mut occupied_text_areas),
+        })
+        .collect()
+}
+
+fn draw_text(text: Text, ctx: &egui::Context, occupied_text_areas: &mut OccupiedAreas) -> Shape {
+    use egui::epaint::TextShape;
+
+    let mut layout_job = egui::text::LayoutJob::default();
+
+    layout_job.append(
+        &text.text,
+        0.0,
+        egui::TextFormat {
+            font_id: egui::FontId::proportional(text.font_size),
+            color: text.text_color,
+            background: text.background_color,
+            ..Default::default()
+        },
+    );
+
+    let galley = ctx.fonts_mut(|fonts| fonts.layout_job(layout_job));
+
+    let area = OrientedRect::new(text.position, text.angle, galley.size());
+    let top_left = area.top_left();
+
+    if occupied_text_areas.try_occupy(area) {
+        TextShape::new(top_left, galley, text.text_color)
+            .with_angle(text.angle)
+            .into()
+    } else {
+        Shape::Noop
+    }
 }
 
 fn get_layer_features(
@@ -419,7 +463,7 @@ fn render_polygon(
     Ok(())
 }
 
-fn render_symbol(
+pub fn render_symbol(
     geometry: &Geometry<f32>,
     context: &Context,
     shapes: &mut Vec<ShapeOrText>,
@@ -427,107 +471,126 @@ fn render_symbol(
     paint: &Option<Paint>,
 ) -> Result<(), Error> {
     match geometry {
-        Geometry::MultiPoint(multi_point) => {
-            let text_size = layout
-                .text_size
-                .as_ref()
-                .and_then(|text_size| {
-                    let size = text_size.evaluate(context);
-
-                    if size > 3.0 {
-                        Some(size)
-                    } else {
-                        warn!(
-                            "{} evaluated into {size}, which is too small for text size.",
-                            text_size.0
-                        );
-                        None
-                    }
-                })
-                .unwrap_or(12.0);
-
-            let text_color = if let Some(paint) = paint
-                && let Some(color) = &paint.text_color
-            {
-                color.evaluate(context)
-            } else {
-                // Default from MapLibre spec.
-                Color32::BLACK
-            };
-
-            if let Some(text) = &layout.text(context) {
-                shapes.extend(multi_point.0.iter().map(|p| {
-                    ShapeOrText::Text(Text::new(
-                        pos2(p.x(), p.y()),
-                        text.clone(),
-                        text_size,
-                        text_color,
-                        Color32::TRANSPARENT,
-                        0.0,
-                    ))
-                }))
-            }
+        Geometry::Point(point) => {
+            label_points(std::slice::from_ref(point), context, shapes, layout, paint)
         }
+        Geometry::MultiPoint(multi_point) => {
+            label_points(&multi_point.0, context, shapes, layout, paint)
+        }
+        Geometry::LineString(line_string) => label_line_strings(
+            std::slice::from_ref(line_string),
+            context,
+            shapes,
+            layout,
+            paint,
+        ),
         Geometry::MultiLineString(multi_line_string) => {
-            let text_size = layout
-                .text_size
-                .as_ref()
-                .and_then(|text_size| {
-                    let size = text_size.evaluate(context);
-
-                    if size > 3.0 {
-                        Some(size)
-                    } else {
-                        warn!(
-                            "{} evaluated into {size}, which is too small for text size.",
-                            text_size.0
-                        );
-                        None
-                    }
-                })
-                .unwrap_or(12.0);
-
-            let text_color = if let Some(paint) = paint
-                && let Some(color) = &paint.text_color
-            {
-                color.evaluate(context)
-            } else {
-                Color32::BLACK
-            };
-
-            let text_halo_color = if let Some(paint) = paint
-                && let Some(color) = &paint.text_halo_color
-            {
-                color.evaluate(context)
-            } else {
-                Color32::TRANSPARENT
-            };
-
-            for line_string in multi_line_string {
-                let lines: Vec<_> = line_string.lines().collect();
-
-                if let Some(text) = &layout.text(context)
-                // Use the longest line to fit the label.
-                && let Some(line) = lines.into_iter().max_by_key(|line| length(line) as u32)
-                {
-                    let mid_point = midpoint(&line.start_point(), &line.end_point());
-                    let angle = line.slope().atan();
-
-                    shapes.push(ShapeOrText::Text(Text::new(
-                        pos2(mid_point.x(), mid_point.y()),
-                        text.clone(),
-                        text_size,
-                        text_color,
-                        // TODO: Implement real halo rendering.
-                        text_halo_color.gamma_multiply(0.5),
-                        angle,
-                    )));
-                }
-            }
+            label_line_strings(&multi_line_string.0, context, shapes, layout, paint)
         }
         _ => (),
     }
     Ok(())
+}
+
+fn label_points(
+    points: &[geo_types::Point<f32>],
+    context: &Context,
+    shapes: &mut Vec<ShapeOrText>,
+    layout: &Layout,
+    paint: &Option<Paint>,
+) {
+    let Some(text) = layout.text(context) else {
+        return;
+    };
+
+    let text_size = evaluate_text_size(layout, context);
+    let text_color = evaluate_text_color(paint, context);
+
+    shapes.extend(points.iter().map(|p| {
+        ShapeOrText::Text(Text::new(
+            pos2(p.x(), p.y()),
+            text.clone(),
+            text_size,
+            text_color,
+            Color32::TRANSPARENT,
+            0.0,
+        ))
+    }))
+}
+
+fn label_line_strings(
+    line_strings: &[geo_types::LineString<f32>],
+    context: &Context,
+    shapes: &mut Vec<ShapeOrText>,
+    layout: &Layout,
+    paint: &Option<Paint>,
+) {
+    let Some(text) = layout.text(context) else {
+        return;
+    };
+
+    let text_size = evaluate_text_size(layout, context);
+    let text_color = evaluate_text_color(paint, context);
+
+    let text_halo_color = if let Some(paint) = paint
+        && let Some(color) = &paint.text_halo_color
+    {
+        color.evaluate(context)
+    } else {
+        Color32::TRANSPARENT
+    };
+
+    for line_string in line_strings {
+        let lines: Vec<_> = line_string.lines().collect();
+
+        // Use the longest line to fit the label.
+        if let Some(line) = lines.into_iter().max_by_key(|line| length(line) as u32) {
+            let mid_point = midpoint(&line.start_point(), &line.end_point());
+            let angle = line.slope().atan();
+
+            shapes.push(ShapeOrText::Text(Text::new(
+                pos2(mid_point.x(), mid_point.y()),
+                text.clone(),
+                text_size,
+                text_color,
+                // TODO: Implement real halo rendering.
+                text_halo_color.gamma_multiply(0.5),
+                angle,
+            )));
+        }
+    }
+}
+
+fn evaluate_text_size(layout: &Layout, context: &Context) -> f32 {
+    layout
+        .text_size
+        .as_ref()
+        .and_then(|text_size| {
+            let size = text_size.evaluate(context);
+
+            if size > 3.0 {
+                Some(size)
+            } else {
+                warn!(
+                    "{} evaluated into {size}, which is too small for text size.",
+                    text_size.0
+                );
+                None
+            }
+        })
+        // Default from MapLibre spec.
+        .unwrap_or(12.0)
+}
+
+fn evaluate_text_color(paint: &Option<Paint>, context: &Context) -> Color32 {
+    if let Some(paint) = paint
+        && let Some(color) = &paint.text_color
+    {
+        color.evaluate(context)
+    } else {
+        // Default from MapLibre spec.
+        Color32::BLACK
+    }
 }
 
 fn length(line: &Line<f32>) -> f32 {
@@ -643,5 +706,74 @@ mod tests {
         // width 2.0 turns the [2, 1] pattern into 4-unit dash, 2-unit gap.
         let segments = dash_polyline(&points, &[2.0, 1.0], 2.0);
         assert_eq!(segments, vec![vec![pos2(0.0, 0.0), pos2(4.0, 0.0)]]);
+    }
+
+    fn label(geometry: Geometry<f32>) -> Vec<ShapeOrText> {
+        let context = Context::new(
+            geometry_type_to_str(&geometry).to_string(),
+            HashMap::from([("name".to_string(), JsonValue::from("Śnieżka"))]),
+            12,
+        );
+
+        let layout = Layout {
+            text_field: Some(crate::style::json!(["get", "name"])),
+            text_size: None,
+        };
+
+        let mut shapes = Vec::new();
+        render_symbol(&geometry, &context, &mut shapes, &layout, &None).unwrap();
+        shapes
+    }
+
+    fn texts(shapes: &[ShapeOrText]) -> Vec<&str> {
+        shapes
+            .iter()
+            .filter_map(|shape| match shape {
+                ShapeOrText::Text(text) => Some(text.text.as_str()),
+                ShapeOrText::Shape(_) => None,
+            })
+            .collect()
+    }
+
+    /// MVT hands over `MultiPoint`, GeoJSON a plain `Point`, and both need labelling.
+    #[test]
+    fn points_are_labelled_whether_they_come_singly_or_not() {
+        let point = geo_types::Point::new(1.0, 2.0);
+
+        assert_eq!(texts(&label(Geometry::Point(point))), ["Śnieżka"]);
+        assert_eq!(
+            texts(&label(Geometry::MultiPoint(
+                vec![point, geo_types::Point::new(3.0, 4.0)].into()
+            ))),
+            ["Śnieżka", "Śnieżka"]
+        );
+    }
+
+    #[test]
+    fn line_strings_are_labelled_whether_they_come_singly_or_not() {
+        let line_string =
+            geo_types::LineString::from(vec![(0.0f32, 0.0f32), (10.0, 0.0), (10.0, 10.0)]);
+
+        assert_eq!(
+            texts(&label(Geometry::LineString(line_string.clone()))),
+            ["Śnieżka"]
+        );
+        assert_eq!(
+            texts(&label(Geometry::MultiLineString(
+                geo_types::MultiLineString::new(vec![line_string.clone(), line_string])
+            ))),
+            ["Śnieżka", "Śnieżka"]
+        );
+    }
+
+    /// Labels are placed on the geometry, not at the origin.
+    #[test]
+    fn a_point_label_lands_on_the_point() {
+        let shapes = label(Geometry::Point(geo_types::Point::new(1.0, 2.0)));
+
+        match shapes.as_slice() {
+            [ShapeOrText::Text(text)] => assert_eq!(text.position, pos2(1.0, 2.0)),
+            other => panic!("expected a single label, got {other:?}"),
+        }
     }
 }

--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -1,14 +1,8 @@
 #[cfg(feature = "mvt")]
 use crate::mvt::{self, ShapeOrText};
-#[cfg(feature = "mvt")]
-use crate::text::Text;
-#[cfg(feature = "mvt")]
-use crate::text::{OccupiedAreas, OrientedRect};
 
 use egui::{Color32, Context, Mesh, Rect, Vec2, pos2};
 use egui::{ColorImage, TextureHandle};
-#[cfg(feature = "mvt")]
-use egui::{FontId, Shape};
 use image::{ImageError, ImageReader};
 use std::collections::HashSet;
 use thiserror::Error;
@@ -177,57 +171,11 @@ impl Tile {
                 // ...and then it can be clipped to the `rect`.
                 let painter = painter.with_clip_rect(rect);
 
-                let mut occupied_text_areas = OccupiedAreas::new();
-
-                // Need to collect it to avoid deadlock caused by `Painter::extend` and `fonts_mut`.
-                let shapes: Vec<_> = mvt::transformed(shapes, full_rect)
-                    .into_iter()
-                    .map(|shape_or_text| match shape_or_text {
-                        ShapeOrText::Shape(shape) => shape,
-                        ShapeOrText::Text(text) => {
-                            self.draw_text(text, painter.ctx(), &mut occupied_text_areas)
-                        }
-                    })
-                    .collect();
-
-                painter.extend(shapes);
+                painter.extend(mvt::resolve_text(
+                    mvt::transformed(shapes, full_rect),
+                    painter.ctx(),
+                ));
             }
-        }
-    }
-
-    #[cfg(feature = "mvt")]
-    fn draw_text(
-        &self,
-        text: Text,
-        ctx: &Context,
-        occupied_text_areas: &mut OccupiedAreas,
-    ) -> Shape {
-        use egui::epaint::TextShape;
-
-        let mut layout_job = egui::text::LayoutJob::default();
-
-        layout_job.append(
-            &text.text,
-            0.0,
-            egui::TextFormat {
-                font_id: FontId::proportional(text.font_size),
-                color: text.text_color,
-                background: text.background_color,
-                ..Default::default()
-            },
-        );
-
-        let galley = ctx.fonts_mut(|fonts| fonts.layout_job(layout_job));
-
-        let area = OrientedRect::new(text.position, text.angle, galley.size());
-        let top_left = area.top_left();
-
-        if occupied_text_areas.try_occupy(area) {
-            TextShape::new(top_left, galley, text.text_color)
-                .with_angle(text.angle)
-                .into()
-        } else {
-            Shape::Noop
         }
     }
 }

--- a/walkers_extras/src/geojson.rs
+++ b/walkers_extras/src/geojson.rs
@@ -7,7 +7,9 @@ use geojson::{Feature as GeoJsonFeature, GeoJson};
 use log::warn;
 use rstar::primitives::{GeomWithData, Rectangle};
 use rstar::{AABB, RTree};
-use walkers::{Context, Layer, Position, Projector, Style, render_line};
+use walkers::{
+    Context, Filter, Layer, Position, Projector, Style, render_line, render_symbol, resolve_text,
+};
 
 struct Feature {
     geometry: walkers::Geometry<f32>,
@@ -57,19 +59,20 @@ impl GeoJsonLayer {
         for layer in &self.style.layers {
             match layer {
                 Layer::Line { paint, filter, .. } => {
-                    for entry in self.rtree.locate_in_envelope_intersecting(viewport) {
-                        let properties = entry.data.properties.clone();
-                        let context =
-                            Context::new("geometry_type/TODO".to_string(), properties, zoom);
-
-                        if let Some(filter) = filter
-                            && !filter.matches(&context)
-                        {
-                            continue;
-                        }
-
-                        let projected = project_geometry(&entry.data.geometry, projector);
+                    for (geometry, context) in self.features(viewport, filter.as_ref(), zoom) {
+                        let projected = project_geometry(geometry, projector);
                         let _ = render_line(&projected, &context, &mut shapes, paint);
+                    }
+                }
+                Layer::Symbol {
+                    layout,
+                    paint,
+                    filter,
+                    ..
+                } => {
+                    for (geometry, context) in self.features(viewport, filter.as_ref(), zoom) {
+                        let projected = project_geometry(geometry, projector);
+                        let _ = render_symbol(&projected, &context, &mut shapes, layout, paint);
                     }
                 }
                 other => {
@@ -78,17 +81,31 @@ impl GeoJsonLayer {
             }
         }
 
-        let painter = ui.painter();
-        for shape in shapes {
-            match shape {
-                walkers::ShapeOrText::Shape(shape) => {
-                    painter.add(shape);
+        let shapes = resolve_text(shapes, ui.ctx());
+        ui.painter().extend(shapes);
+    }
+
+    /// Features in the viewport which the layer's filter lets through.
+    fn features<'a>(
+        &'a self,
+        viewport: AABB<[f64; 2]>,
+        filter: Option<&'a Filter>,
+        zoom: u8,
+    ) -> impl Iterator<Item = (&'a walkers::Geometry<f32>, Context)> + 'a {
+        self.rtree
+            .locate_in_envelope_intersecting(viewport)
+            .filter_map(move |entry| {
+                let context = Context::new(
+                    "geometry_type/TODO".to_string(),
+                    entry.data.properties.clone(),
+                    zoom,
+                );
+
+                match filter {
+                    Some(filter) if !filter.matches(&context) => None,
+                    _ => Some((&entry.data.geometry, context)),
                 }
-                walkers::ShapeOrText::Text(_) => {
-                    // Text rendering not yet supported for GeoJSON layers.
-                }
-            }
-        }
+            })
     }
 }
 


### PR DESCRIPTION
Point features were invisible. Only `Layer::Line` was handled, everything else warned and was skipped, and the labels which `render_symbol` produces were matched but thrown away instead of painted.

`render_symbol` also only accepted the `Multi` geometry variants, which is what MVT hands over, so the singular ones GeoJSON keeps would have fallen through unrendered anyway. Both are taken now, the way `render_line` already took both.

Painting the labels means laying them out and resolving their collisions, which tiles already did privately. That moves into `mvt::resolve_text`, so there is one such pass rather than a copy per source.

Peaks make for point features to actually look at: `just overpass-peaks-dolnoslaskie` fetches a few thousand of them, and the demo style grows a symbol layer which filters them out of whatever `.geojson` files are lying around. The downloads are ignored, like `*.pmtiles`.

 * [ ] Map is displaying and reacting to input correctly, both natively and on the web.
 * [ ] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
