### PR TITLE
Extract a `render` module out of `mvt`

### DIFF
--- a/walkers/src/lib.rs
+++ b/walkers/src/lib.rs
@@ -32,6 +32,8 @@ mod mvt;
 mod pmtiles;
 mod position;
 mod projector;
+#[cfg(feature = "mvt")]
+mod render;
 pub mod sources;
 mod tiles;
 mod zoom;
@@ -58,6 +60,6 @@ pub use zoom::InvalidZoom;
 #[cfg(feature = "mvt")]
 pub use expression::Context;
 #[cfg(feature = "mvt")]
-pub use mvt::{
+pub use render::{
     Geometry, ShapeOrText, render_line, render_symbol, resolve_text, tessellate_polygon,
 };

--- a/walkers/src/mvt.rs
+++ b/walkers/src/mvt.rs
@@ -2,28 +2,15 @@
 
 use std::collections::HashMap;
 
-use egui::{
-    Color32, Mesh, Rect, Shape, Stroke,
-    emath::TSTransform,
-    epaint::{Vertex, WHITE_UV},
-    pos2, vec2,
-};
-pub use geo_types::{Coord, Geometry, Line};
+use egui::{Color32, Rect, Shape, emath::TSTransform, pos2, vec2};
 use log::warn;
-use lyon_path::{
-    Path, Polygon,
-    geom::{Point, point},
-};
-use lyon_tessellation::{
-    BuffersBuilder, FillOptions, FillTessellator, FillVertex, TessellationError, VertexBuffers,
-};
 use mvt_reader::{Reader, feature::Value};
 use serde_json::{Number, Value as JsonValue};
 
 use crate::{
     expression::Context,
-    style::{Filter, Layer, Layout, Paint, Style},
-    text::{OccupiedAreas, OrientedRect, Text},
+    render::{self, Geometry, ShapeOrText},
+    style::{Filter, Layer, Style},
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -34,14 +21,6 @@ pub enum Error {
     LayerNotFound(String, Vec<String>),
     #[error("Unsupported layer extent: {0}")]
     UnsupportedLayerExtent(String),
-    #[error("Unsupported kind: {0:?}")]
-    UnsupportedFeatureKind(HashMap<String, Value>),
-    #[error("Missing kind in properties: {0:?}")]
-    FeatureWithoutKind(HashMap<String, Value>),
-    #[error("Missing properties in feature")]
-    FeatureWithoutProperties,
-    #[error(transparent)]
-    Tessellation(#[from] TessellationError),
 }
 
 /// Custom conversion because mvt_reader::error::Error is not Send.
@@ -53,38 +32,6 @@ impl From<mvt_reader::error::ParserError> for Error {
 
 /// Currently this is the only supported extent.
 const ONLY_SUPPORTED_EXTENT: u32 = 4096;
-
-#[derive(Debug, Clone)]
-pub enum ShapeOrText {
-    Shape(Shape),
-    Text(Text),
-}
-
-impl From<Shape> for ShapeOrText {
-    fn from(shape: Shape) -> Self {
-        ShapeOrText::Shape(shape)
-    }
-}
-
-impl From<Mesh> for ShapeOrText {
-    fn from(mesh: Mesh) -> Self {
-        ShapeOrText::Shape(Shape::Mesh(mesh.into()))
-    }
-}
-
-impl ShapeOrText {
-    pub fn transform(&mut self, transform: TSTransform) {
-        match self {
-            ShapeOrText::Shape(shape) => {
-                shape.transform(transform);
-            }
-            ShapeOrText::Text(Text { position, .. }) => {
-                *position *= transform.scaling;
-                *position += transform.translation;
-            }
-        }
-    }
-}
 
 /// Render MVT data into a list of [`epaint::Shape`]s.
 pub fn render(data: &[u8], style: &Style, zoom: u8) -> Result<Vec<ShapeOrText>, Error> {
@@ -116,7 +63,9 @@ pub fn render(data: &[u8], style: &Style, zoom: u8) -> Result<Vec<ShapeOrText>, 
                 for (geometry, context) in
                     get_layer_features(&data, zoom, source_layer, filter.as_ref())?
                 {
-                    if let Err(err) = render_polygon(&geometry, &context, &mut shapes, paint) {
+                    if let Err(err) =
+                        render::render_polygon(&geometry, &context, &mut shapes, paint)
+                    {
                         warn!("{err}");
                     }
                 }
@@ -129,7 +78,7 @@ pub fn render(data: &[u8], style: &Style, zoom: u8) -> Result<Vec<ShapeOrText>, 
                 for (geometry, context) in
                     get_layer_features(&data, zoom, source_layer, filter.as_ref())?
                 {
-                    if let Err(err) = render_line(&geometry, &context, &mut shapes, paint) {
+                    if let Err(err) = render::render_line(&geometry, &context, &mut shapes, paint) {
                         warn!("{err}");
                     }
                 }
@@ -143,7 +92,8 @@ pub fn render(data: &[u8], style: &Style, zoom: u8) -> Result<Vec<ShapeOrText>, 
                 for (geometry, context) in
                     get_layer_features(&data, zoom, source_layer, filter.as_ref())?
                 {
-                    if let Err(err) = render_symbol(&geometry, &context, &mut shapes, layout, paint)
+                    if let Err(err) =
+                        render::render_symbol(&geometry, &context, &mut shapes, layout, paint)
                     {
                         warn!("{err}");
                     }
@@ -174,50 +124,6 @@ pub fn transformed(shapes: &[ShapeOrText], rect: egui::Rect) -> Vec<ShapeOrText>
     result
 }
 
-/// Lay out the labels, dropping the ones which would land on top of an already placed one.
-pub fn resolve_text(shapes: Vec<ShapeOrText>, ctx: &egui::Context) -> Vec<Shape> {
-    let mut occupied_text_areas = OccupiedAreas::new();
-
-    // Need to collect it to avoid deadlock caused by `Painter::extend` and `fonts_mut`.
-    shapes
-        .into_iter()
-        .map(|shape_or_text| match shape_or_text {
-            ShapeOrText::Shape(shape) => shape,
-            ShapeOrText::Text(text) => draw_text(text, ctx, &mut occupied_text_areas),
-        })
-        .collect()
-}
-
-fn draw_text(text: Text, ctx: &egui::Context, occupied_text_areas: &mut OccupiedAreas) -> Shape {
-    use egui::epaint::TextShape;
-
-    let mut layout_job = egui::text::LayoutJob::default();
-
-    layout_job.append(
-        &text.text,
-        0.0,
-        egui::TextFormat {
-            font_id: egui::FontId::proportional(text.font_size),
-            color: text.text_color,
-            background: text.background_color,
-            ..Default::default()
-        },
-    );
-
-    let galley = ctx.fonts_mut(|fonts| fonts.layout_job(layout_job));
-
-    let area = OrientedRect::new(text.position, text.angle, galley.size());
-    let top_left = area.top_left();
-
-    if occupied_text_areas.try_occupy(area) {
-        TextShape::new(top_left, galley, text.text_color)
-            .with_angle(text.angle)
-            .into()
-    } else {
-        Shape::Noop
-    }
-}
-
 fn get_layer_features(
     reader: &Reader,
     zoom: u8,
@@ -242,7 +148,7 @@ fn get_layer_features(
 
     let features = raw.into_iter().filter_map(move |feature| {
         let context = Context::new(
-            geometry_type_to_str(&feature.geometry).to_string(),
+            render::geometry_type_to_str(&feature.geometry).to_string(),
             feature
                 .properties
                 .map_or(Default::default(), mvt_properties_to_json_properties),
@@ -285,322 +191,6 @@ fn mvt_value_to_json_value(value: &Value) -> JsonValue {
     }
 }
 
-fn geometry_type_to_str(geometry: &Geometry<f32>) -> &'static str {
-    match geometry {
-        Geometry::Point(_) | Geometry::MultiPoint(_) => "Point",
-        Geometry::Line(_) => "Line",
-        Geometry::LineString(_) | Geometry::MultiLineString(_) => "LineString",
-        Geometry::Polygon(_) | Geometry::MultiPolygon(_) => "Polygon",
-        Geometry::GeometryCollection(_) => "GeometryCollection",
-        Geometry::Rect(_) => "Rect",
-        Geometry::Triangle(_) => "Triangle",
-    }
-}
-
-pub fn render_line(
-    geometry: &Geometry<f32>,
-    context: &Context,
-    shapes: &mut Vec<ShapeOrText>,
-    paint: &Paint,
-) -> Result<(), Error> {
-    let width = if let Some(width) = &paint.line_width {
-        // Align to the proportion of MVT extent and tile size.
-        width.evaluate(context) * 4.0
-    } else {
-        2.0
-    };
-
-    let opacity = if let Some(opacity) = &paint.line_opacity {
-        opacity.evaluate(context)
-    } else {
-        1.0
-    };
-
-    let color = if let Some(color) = &paint.line_color {
-        color.evaluate(context).gamma_multiply(opacity)
-    } else {
-        Color32::WHITE
-    };
-
-    let dasharray = paint
-        .line_dasharray
-        .as_ref()
-        .and_then(|dasharray| dasharray.evaluate(context));
-
-    let stroke = Stroke::new(width, color);
-
-    match geometry {
-        Geometry::LineString(line_string) => {
-            let points = line_string
-                .0
-                .iter()
-                .map(|p| pos2(p.x, p.y))
-                .collect::<Vec<_>>();
-            push_line(shapes, points, stroke, dasharray.as_deref());
-        }
-        Geometry::MultiLineString(multi_line_string) => {
-            for line_string in multi_line_string {
-                let points = line_string
-                    .0
-                    .iter()
-                    .map(|p| pos2(p.x, p.y))
-                    .collect::<Vec<_>>();
-                push_line(shapes, points, stroke, dasharray.as_deref());
-            }
-        }
-        _ => (),
-    }
-
-    Ok(())
-}
-
-/// Push a polyline as one or more shapes, splitting it into dashes if `dasharray` is given.
-fn push_line(
-    shapes: &mut Vec<ShapeOrText>,
-    points: Vec<egui::Pos2>,
-    stroke: Stroke,
-    dasharray: Option<&[f32]>,
-) {
-    match dasharray {
-        Some(pattern) if !pattern.is_empty() => {
-            for segment in dash_polyline(&points, pattern, stroke.width) {
-                if segment.len() >= 2 {
-                    shapes.push(Shape::line(segment, stroke).into());
-                }
-            }
-        }
-        _ => shapes.push(Shape::line(points, stroke).into()),
-    }
-}
-
-/// Split a polyline into the "on" (dash) runs of a dash/gap `pattern`, whose values are
-/// in units of `width` per the MapLibre `line-dasharray` spec. Each returned run is a
-/// standalone polyline meant to be drawn as its own [`Shape::line`].
-fn dash_polyline(points: &[egui::Pos2], pattern: &[f32], width: f32) -> Vec<Vec<egui::Pos2>> {
-    let pattern = pattern
-        .iter()
-        .map(|value| value * width)
-        .collect::<Vec<_>>();
-
-    if points.len() < 2 || pattern.iter().sum::<f32>() <= 0.0 {
-        return vec![points.to_vec()];
-    }
-
-    let mut segments = Vec::new();
-    let mut current = vec![points[0]];
-    let mut pattern_index = 0;
-    let mut remaining = pattern[0];
-    let mut drawing = true;
-
-    for window in points.windows(2) {
-        let (mut start, end) = (window[0], window[1]);
-        let mut length = start.distance(end);
-
-        while length > 0.0 {
-            if remaining >= length {
-                remaining -= length;
-                if drawing {
-                    current.push(end);
-                }
-                length = 0.0;
-            } else {
-                let point = start + (end - start) * (remaining / length);
-
-                if drawing {
-                    current.push(point);
-                    segments.push(std::mem::take(&mut current));
-                } else {
-                    current = vec![point];
-                }
-
-                length -= remaining;
-                start = point;
-                drawing = !drawing;
-                pattern_index = (pattern_index + 1) % pattern.len();
-                remaining = pattern[pattern_index];
-            }
-        }
-    }
-
-    if drawing && current.len() > 1 {
-        segments.push(current);
-    }
-
-    segments
-}
-
-fn render_polygon(
-    geometry: &Geometry<f32>,
-    context: &Context,
-    shapes: &mut Vec<ShapeOrText>,
-    paint: &Paint,
-) -> Result<(), Error> {
-    if let Geometry::MultiPolygon(multi_polygon) = geometry {
-        let Some(fill_color) = &paint.fill_color else {
-            warn!("Fill layer without fill color. Skipping.");
-            return Ok(());
-        };
-
-        let fill_color = fill_color.evaluate(context);
-
-        let fill_color = if let Some(fill_opacity) = &paint.fill_opacity {
-            let fill_opacity = fill_opacity.evaluate(context);
-            fill_color.gamma_multiply(fill_opacity)
-        } else {
-            fill_color
-        };
-
-        for polygon in multi_polygon.iter() {
-            let exterior = lyon_points(&polygon.exterior().0);
-            let interiors = polygon
-                .interiors()
-                .iter()
-                .map(|hole| lyon_points(&hole.0))
-                .collect::<Vec<_>>();
-            shapes.push(tessellate_polygon(&exterior, &interiors, fill_color)?.into());
-        }
-    }
-    Ok(())
-}
-
-pub fn render_symbol(
-    geometry: &Geometry<f32>,
-    context: &Context,
-    shapes: &mut Vec<ShapeOrText>,
-    layout: &Layout,
-    paint: &Option<Paint>,
-) -> Result<(), Error> {
-    match geometry {
-        Geometry::Point(point) => {
-            label_points(std::slice::from_ref(point), context, shapes, layout, paint)
-        }
-        Geometry::MultiPoint(multi_point) => {
-            label_points(&multi_point.0, context, shapes, layout, paint)
-        }
-        Geometry::LineString(line_string) => label_line_strings(
-            std::slice::from_ref(line_string),
-            context,
-            shapes,
-            layout,
-            paint,
-        ),
-        Geometry::MultiLineString(multi_line_string) => {
-            label_line_strings(&multi_line_string.0, context, shapes, layout, paint)
-        }
-        _ => (),
-    }
-    Ok(())
-}
-
-fn label_points(
-    points: &[geo_types::Point<f32>],
-    context: &Context,
-    shapes: &mut Vec<ShapeOrText>,
-    layout: &Layout,
-    paint: &Option<Paint>,
-) {
-    let Some(text) = layout.text(context) else {
-        return;
-    };
-
-    let text_size = evaluate_text_size(layout, context);
-    let text_color = evaluate_text_color(paint, context);
-
-    shapes.extend(points.iter().map(|p| {
-        ShapeOrText::Text(Text::new(
-            pos2(p.x(), p.y()),
-            text.clone(),
-            text_size,
-            text_color,
-            Color32::TRANSPARENT,
-            0.0,
-        ))
-    }))
-}
-
-fn label_line_strings(
-    line_strings: &[geo_types::LineString<f32>],
-    context: &Context,
-    shapes: &mut Vec<ShapeOrText>,
-    layout: &Layout,
-    paint: &Option<Paint>,
-) {
-    let Some(text) = layout.text(context) else {
-        return;
-    };
-
-    let text_size = evaluate_text_size(layout, context);
-    let text_color = evaluate_text_color(paint, context);
-
-    let text_halo_color = if let Some(paint) = paint
-        && let Some(color) = &paint.text_halo_color
-    {
-        color.evaluate(context)
-    } else {
-        Color32::TRANSPARENT
-    };
-
-    for line_string in line_strings {
-        let lines: Vec<_> = line_string.lines().collect();
-
-        // Use the longest line to fit the label.
-        if let Some(line) = lines.into_iter().max_by_key(|line| length(line) as u32) {
-            let mid_point = midpoint(&line.start_point(), &line.end_point());
-            let angle = line.slope().atan();
-
-            shapes.push(ShapeOrText::Text(Text::new(
-                pos2(mid_point.x(), mid_point.y()),
-                text.clone(),
-                text_size,
-                text_color,
-                // TODO: Implement real halo rendering.
-                text_halo_color.gamma_multiply(0.5),
-                angle,
-            )));
-        }
-    }
-}
-
-fn evaluate_text_size(layout: &Layout, context: &Context) -> f32 {
-    layout
-        .text_size
-        .as_ref()
-        .and_then(|text_size| {
-            let size = text_size.evaluate(context);
-
-            if size > 3.0 {
-                Some(size)
-            } else {
-                warn!(
-                    "{} evaluated into {size}, which is too small for text size.",
-                    text_size.0
-                );
-                None
-            }
-        })
-        // Default from MapLibre spec.
-        .unwrap_or(12.0)
-}
-
-fn evaluate_text_color(paint: &Option<Paint>, context: &Context) -> Color32 {
-    if let Some(paint) = paint
-        && let Some(color) = &paint.text_color
-    {
-        color.evaluate(context)
-    } else {
-        // Default from MapLibre spec.
-        Color32::BLACK
-    }
-}
-
-fn length(line: &Line<f32>) -> f32 {
-    (line.dx() * line.dx() + line.dy() * line.dy()).sqrt()
-}
-
-fn midpoint(p1: &geo_types::Point<f32>, p2: &geo_types::Point<f32>) -> geo_types::Point<f32> {
-    geo_types::Point::new((p1.x() + p2.x()) / 2.0, (p1.y() + p2.y()) / 2.0)
-}
-
 fn find_layer(data: &Reader, name: &str) -> Result<usize, Error> {
     let layer = data
         .get_layer_metadata()?
@@ -619,161 +209,4 @@ fn find_layer(data: &Reader, name: &str) -> Result<usize, Error> {
     }
 
     Ok(layer.layer_index)
-}
-
-/// Egui cannot tessellate complex polygons, so we use lyon for that.
-pub fn tessellate_polygon(
-    exterior: &[Point<f32>],
-    interiors: &[Vec<Point<f32>>],
-    fill_color: Color32,
-) -> Result<Mesh, TessellationError> {
-    let mut builder = Path::builder();
-
-    builder.add_polygon(Polygon {
-        points: exterior,
-        closed: true,
-    });
-
-    for interior in interiors {
-        builder.add_polygon(Polygon {
-            points: interior,
-            closed: true,
-        });
-    }
-
-    let mut buffers: VertexBuffers<Vertex, u32> = VertexBuffers::new();
-
-    FillTessellator::new().tessellate_path(
-        &builder.build(),
-        &FillOptions::default(),
-        &mut BuffersBuilder::new(&mut buffers, |vertex: FillVertex| {
-            let pos = vertex.position();
-            Vertex {
-                pos: pos2(pos.x, pos.y),
-                uv: WHITE_UV,
-                color: fill_color,
-            }
-        }),
-    )?;
-
-    Ok(Mesh {
-        indices: buffers.indices,
-        vertices: buffers.vertices,
-        ..Default::default()
-    })
-}
-
-/// Convert list of `geo_types::Coord` to Lyon's `Point`s.
-fn lyon_points(points: &[Coord<f32>]) -> Vec<Point<f32>> {
-    points.iter().map(|p| point(p.x, p.y)).collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn dash_polyline_without_pattern_keeps_a_single_segment() {
-        let points = vec![pos2(0.0, 0.0), pos2(10.0, 0.0)];
-        let segments = dash_polyline(&points, &[], 1.0);
-        assert_eq!(segments, vec![points]);
-    }
-
-    #[test]
-    fn dash_polyline_splits_dashes_and_gaps() {
-        // Pattern [2, 1] at width 1.0 means a 2-unit dash followed by a 1-unit gap,
-        // repeating. Over a 10-unit straight line that's dash/gap/dash/gap/dash/gap...
-        let points = vec![pos2(0.0, 0.0), pos2(9.0, 0.0)];
-        let segments = dash_polyline(&points, &[2.0, 1.0], 1.0);
-
-        assert_eq!(
-            segments,
-            vec![
-                vec![pos2(0.0, 0.0), pos2(2.0, 0.0)],
-                vec![pos2(3.0, 0.0), pos2(5.0, 0.0)],
-                vec![pos2(6.0, 0.0), pos2(8.0, 0.0)],
-                vec![pos2(9.0, 0.0)],
-            ]
-            .into_iter()
-            .filter(|segment: &Vec<egui::Pos2>| segment.len() >= 2)
-            .collect::<Vec<_>>()
-        );
-    }
-
-    #[test]
-    fn dash_polyline_pattern_scales_with_line_width() {
-        let points = vec![pos2(0.0, 0.0), pos2(4.0, 0.0)];
-        // width 2.0 turns the [2, 1] pattern into 4-unit dash, 2-unit gap.
-        let segments = dash_polyline(&points, &[2.0, 1.0], 2.0);
-        assert_eq!(segments, vec![vec![pos2(0.0, 0.0), pos2(4.0, 0.0)]]);
-    }
-
-    fn label(geometry: Geometry<f32>) -> Vec<ShapeOrText> {
-        let context = Context::new(
-            geometry_type_to_str(&geometry).to_string(),
-            HashMap::from([("name".to_string(), JsonValue::from("Śnieżka"))]),
-            12,
-        );
-
-        let layout = Layout {
-            text_field: Some(crate::style::json!(["get", "name"])),
-            text_size: None,
-        };
-
-        let mut shapes = Vec::new();
-        render_symbol(&geometry, &context, &mut shapes, &layout, &None).unwrap();
-        shapes
-    }
-
-    fn texts(shapes: &[ShapeOrText]) -> Vec<&str> {
-        shapes
-            .iter()
-            .filter_map(|shape| match shape {
-                ShapeOrText::Text(text) => Some(text.text.as_str()),
-                ShapeOrText::Shape(_) => None,
-            })
-            .collect()
-    }
-
-    /// MVT hands over `MultiPoint`, GeoJSON a plain `Point`, and both need labelling.
-    #[test]
-    fn points_are_labelled_whether_they_come_singly_or_not() {
-        let point = geo_types::Point::new(1.0, 2.0);
-
-        assert_eq!(texts(&label(Geometry::Point(point))), ["Śnieżka"]);
-        assert_eq!(
-            texts(&label(Geometry::MultiPoint(
-                vec![point, geo_types::Point::new(3.0, 4.0)].into()
-            ))),
-            ["Śnieżka", "Śnieżka"]
-        );
-    }
-
-    #[test]
-    fn line_strings_are_labelled_whether_they_come_singly_or_not() {
-        let line_string =
-            geo_types::LineString::from(vec![(0.0f32, 0.0f32), (10.0, 0.0), (10.0, 10.0)]);
-
-        assert_eq!(
-            texts(&label(Geometry::LineString(line_string.clone()))),
-            ["Śnieżka"]
-        );
-        assert_eq!(
-            texts(&label(Geometry::MultiLineString(
-                geo_types::MultiLineString::new(vec![line_string.clone(), line_string])
-            ))),
-            ["Śnieżka", "Śnieżka"]
-        );
-    }
-
-    /// Labels are placed on the geometry, not at the origin.
-    #[test]
-    fn a_point_label_lands_on_the_point() {
-        let shapes = label(Geometry::Point(geo_types::Point::new(1.0, 2.0)));
-
-        match shapes.as_slice() {
-            [ShapeOrText::Text(text)] => assert_eq!(text.position, pos2(1.0, 2.0)),
-            other => panic!("expected a single label, got {other:?}"),
-        }
-    }
 }

--- a/walkers/src/render.rs
+++ b/walkers/src/render.rs
@@ -1,0 +1,551 @@
+//! Draw geometries the way a [`crate::Style`] says to.
+//!
+//! Where the geometries came from - vector tiles, GeoJSON, KML - is not this module's concern.
+
+use egui::{
+    Color32, Mesh, Shape, Stroke,
+    emath::TSTransform,
+    epaint::{Vertex, WHITE_UV},
+    pos2,
+};
+pub use geo_types::{Coord, Geometry, Line};
+use log::warn;
+use lyon_path::{
+    Path, Polygon,
+    geom::{Point, point},
+};
+use lyon_tessellation::{
+    BuffersBuilder, FillOptions, FillTessellator, FillVertex, TessellationError, VertexBuffers,
+};
+
+use crate::{
+    expression::Context,
+    style::{Layout, Paint},
+    text::{OccupiedAreas, Text, draw_text},
+};
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Tessellation(#[from] TessellationError),
+}
+
+#[derive(Debug, Clone)]
+pub enum ShapeOrText {
+    Shape(Shape),
+    Text(Text),
+}
+
+impl From<Shape> for ShapeOrText {
+    fn from(shape: Shape) -> Self {
+        ShapeOrText::Shape(shape)
+    }
+}
+
+impl From<Mesh> for ShapeOrText {
+    fn from(mesh: Mesh) -> Self {
+        ShapeOrText::Shape(Shape::Mesh(mesh.into()))
+    }
+}
+
+impl ShapeOrText {
+    pub fn transform(&mut self, transform: TSTransform) {
+        match self {
+            ShapeOrText::Shape(shape) => {
+                shape.transform(transform);
+            }
+            ShapeOrText::Text(Text { position, .. }) => {
+                *position *= transform.scaling;
+                *position += transform.translation;
+            }
+        }
+    }
+}
+
+/// Lay out the labels, dropping the ones which would land on top of an already placed one.
+pub fn resolve_text(shapes: Vec<ShapeOrText>, ctx: &egui::Context) -> Vec<Shape> {
+    let mut occupied_text_areas = OccupiedAreas::new();
+
+    // Need to collect it to avoid deadlock caused by `Painter::extend` and `fonts_mut`.
+    shapes
+        .into_iter()
+        .map(|shape_or_text| match shape_or_text {
+            ShapeOrText::Shape(shape) => shape,
+            ShapeOrText::Text(text) => draw_text(text, ctx, &mut occupied_text_areas),
+        })
+        .collect()
+}
+
+pub(crate) fn geometry_type_to_str(geometry: &Geometry<f32>) -> &'static str {
+    match geometry {
+        Geometry::Point(_) | Geometry::MultiPoint(_) => "Point",
+        Geometry::Line(_) => "Line",
+        Geometry::LineString(_) | Geometry::MultiLineString(_) => "LineString",
+        Geometry::Polygon(_) | Geometry::MultiPolygon(_) => "Polygon",
+        Geometry::GeometryCollection(_) => "GeometryCollection",
+        Geometry::Rect(_) => "Rect",
+        Geometry::Triangle(_) => "Triangle",
+    }
+}
+
+pub fn render_line(
+    geometry: &Geometry<f32>,
+    context: &Context,
+    shapes: &mut Vec<ShapeOrText>,
+    paint: &Paint,
+) -> Result<(), Error> {
+    let width = if let Some(width) = &paint.line_width {
+        // Align to the proportion of MVT extent and tile size.
+        width.evaluate(context) * 4.0
+    } else {
+        2.0
+    };
+
+    let opacity = if let Some(opacity) = &paint.line_opacity {
+        opacity.evaluate(context)
+    } else {
+        1.0
+    };
+
+    let color = if let Some(color) = &paint.line_color {
+        color.evaluate(context).gamma_multiply(opacity)
+    } else {
+        Color32::WHITE
+    };
+
+    let dasharray = paint
+        .line_dasharray
+        .as_ref()
+        .and_then(|dasharray| dasharray.evaluate(context));
+
+    let stroke = Stroke::new(width, color);
+
+    match geometry {
+        Geometry::LineString(line_string) => {
+            let points = line_string
+                .0
+                .iter()
+                .map(|p| pos2(p.x, p.y))
+                .collect::<Vec<_>>();
+            push_line(shapes, points, stroke, dasharray.as_deref());
+        }
+        Geometry::MultiLineString(multi_line_string) => {
+            for line_string in multi_line_string {
+                let points = line_string
+                    .0
+                    .iter()
+                    .map(|p| pos2(p.x, p.y))
+                    .collect::<Vec<_>>();
+                push_line(shapes, points, stroke, dasharray.as_deref());
+            }
+        }
+        _ => (),
+    }
+
+    Ok(())
+}
+
+/// Push a polyline as one or more shapes, splitting it into dashes if `dasharray` is given.
+fn push_line(
+    shapes: &mut Vec<ShapeOrText>,
+    points: Vec<egui::Pos2>,
+    stroke: Stroke,
+    dasharray: Option<&[f32]>,
+) {
+    match dasharray {
+        Some(pattern) if !pattern.is_empty() => {
+            for segment in dash_polyline(&points, pattern, stroke.width) {
+                if segment.len() >= 2 {
+                    shapes.push(Shape::line(segment, stroke).into());
+                }
+            }
+        }
+        _ => shapes.push(Shape::line(points, stroke).into()),
+    }
+}
+
+/// Split a polyline into the "on" (dash) runs of a dash/gap `pattern`, whose values are
+/// in units of `width` per the MapLibre `line-dasharray` spec. Each returned run is a
+/// standalone polyline meant to be drawn as its own [`Shape::line`].
+fn dash_polyline(points: &[egui::Pos2], pattern: &[f32], width: f32) -> Vec<Vec<egui::Pos2>> {
+    let pattern = pattern
+        .iter()
+        .map(|value| value * width)
+        .collect::<Vec<_>>();
+
+    if points.len() < 2 || pattern.iter().sum::<f32>() <= 0.0 {
+        return vec![points.to_vec()];
+    }
+
+    let mut segments = Vec::new();
+    let mut current = vec![points[0]];
+    let mut pattern_index = 0;
+    let mut remaining = pattern[0];
+    let mut drawing = true;
+
+    for window in points.windows(2) {
+        let (mut start, end) = (window[0], window[1]);
+        let mut length = start.distance(end);
+
+        while length > 0.0 {
+            if remaining >= length {
+                remaining -= length;
+                if drawing {
+                    current.push(end);
+                }
+                length = 0.0;
+            } else {
+                let point = start + (end - start) * (remaining / length);
+
+                if drawing {
+                    current.push(point);
+                    segments.push(std::mem::take(&mut current));
+                } else {
+                    current = vec![point];
+                }
+
+                length -= remaining;
+                start = point;
+                drawing = !drawing;
+                pattern_index = (pattern_index + 1) % pattern.len();
+                remaining = pattern[pattern_index];
+            }
+        }
+    }
+
+    if drawing && current.len() > 1 {
+        segments.push(current);
+    }
+
+    segments
+}
+
+pub(crate) fn render_polygon(
+    geometry: &Geometry<f32>,
+    context: &Context,
+    shapes: &mut Vec<ShapeOrText>,
+    paint: &Paint,
+) -> Result<(), Error> {
+    if let Geometry::MultiPolygon(multi_polygon) = geometry {
+        let Some(fill_color) = &paint.fill_color else {
+            warn!("Fill layer without fill color. Skipping.");
+            return Ok(());
+        };
+
+        let fill_color = fill_color.evaluate(context);
+
+        let fill_color = if let Some(fill_opacity) = &paint.fill_opacity {
+            let fill_opacity = fill_opacity.evaluate(context);
+            fill_color.gamma_multiply(fill_opacity)
+        } else {
+            fill_color
+        };
+
+        for polygon in multi_polygon.iter() {
+            let exterior = lyon_points(&polygon.exterior().0);
+            let interiors = polygon
+                .interiors()
+                .iter()
+                .map(|hole| lyon_points(&hole.0))
+                .collect::<Vec<_>>();
+            shapes.push(tessellate_polygon(&exterior, &interiors, fill_color)?.into());
+        }
+    }
+    Ok(())
+}
+
+pub fn render_symbol(
+    geometry: &Geometry<f32>,
+    context: &Context,
+    shapes: &mut Vec<ShapeOrText>,
+    layout: &Layout,
+    paint: &Option<Paint>,
+) -> Result<(), Error> {
+    match geometry {
+        Geometry::Point(point) => {
+            label_points(std::slice::from_ref(point), context, shapes, layout, paint)
+        }
+        Geometry::MultiPoint(multi_point) => {
+            label_points(&multi_point.0, context, shapes, layout, paint)
+        }
+        Geometry::LineString(line_string) => label_line_strings(
+            std::slice::from_ref(line_string),
+            context,
+            shapes,
+            layout,
+            paint,
+        ),
+        Geometry::MultiLineString(multi_line_string) => {
+            label_line_strings(&multi_line_string.0, context, shapes, layout, paint)
+        }
+        _ => (),
+    }
+    Ok(())
+}
+
+fn label_points(
+    points: &[geo_types::Point<f32>],
+    context: &Context,
+    shapes: &mut Vec<ShapeOrText>,
+    layout: &Layout,
+    paint: &Option<Paint>,
+) {
+    let Some(text) = layout.text(context) else {
+        return;
+    };
+
+    let text_size = evaluate_text_size(layout, context);
+    let text_color = evaluate_text_color(paint, context);
+
+    shapes.extend(points.iter().map(|p| {
+        ShapeOrText::Text(Text::new(
+            pos2(p.x(), p.y()),
+            text.clone(),
+            text_size,
+            text_color,
+            Color32::TRANSPARENT,
+            0.0,
+        ))
+    }))
+}
+
+fn label_line_strings(
+    line_strings: &[geo_types::LineString<f32>],
+    context: &Context,
+    shapes: &mut Vec<ShapeOrText>,
+    layout: &Layout,
+    paint: &Option<Paint>,
+) {
+    let Some(text) = layout.text(context) else {
+        return;
+    };
+
+    let text_size = evaluate_text_size(layout, context);
+    let text_color = evaluate_text_color(paint, context);
+
+    let text_halo_color = if let Some(paint) = paint
+        && let Some(color) = &paint.text_halo_color
+    {
+        color.evaluate(context)
+    } else {
+        Color32::TRANSPARENT
+    };
+
+    for line_string in line_strings {
+        let lines: Vec<_> = line_string.lines().collect();
+
+        // Use the longest line to fit the label.
+        if let Some(line) = lines.into_iter().max_by_key(|line| length(line) as u32) {
+            let mid_point = midpoint(&line.start_point(), &line.end_point());
+            let angle = line.slope().atan();
+
+            shapes.push(ShapeOrText::Text(Text::new(
+                pos2(mid_point.x(), mid_point.y()),
+                text.clone(),
+                text_size,
+                text_color,
+                // TODO: Implement real halo rendering.
+                text_halo_color.gamma_multiply(0.5),
+                angle,
+            )));
+        }
+    }
+}
+
+fn evaluate_text_size(layout: &Layout, context: &Context) -> f32 {
+    layout
+        .text_size
+        .as_ref()
+        .and_then(|text_size| {
+            let size = text_size.evaluate(context);
+
+            if size > 3.0 {
+                Some(size)
+            } else {
+                warn!(
+                    "{} evaluated into {size}, which is too small for text size.",
+                    text_size.0
+                );
+                None
+            }
+        })
+        // Default from MapLibre spec.
+        .unwrap_or(12.0)
+}
+
+fn evaluate_text_color(paint: &Option<Paint>, context: &Context) -> Color32 {
+    if let Some(paint) = paint
+        && let Some(color) = &paint.text_color
+    {
+        color.evaluate(context)
+    } else {
+        // Default from MapLibre spec.
+        Color32::BLACK
+    }
+}
+
+fn length(line: &Line<f32>) -> f32 {
+    (line.dx() * line.dx() + line.dy() * line.dy()).sqrt()
+}
+
+fn midpoint(p1: &geo_types::Point<f32>, p2: &geo_types::Point<f32>) -> geo_types::Point<f32> {
+    geo_types::Point::new((p1.x() + p2.x()) / 2.0, (p1.y() + p2.y()) / 2.0)
+}
+
+/// Egui cannot tessellate complex polygons, so we use lyon for that.
+pub fn tessellate_polygon(
+    exterior: &[Point<f32>],
+    interiors: &[Vec<Point<f32>>],
+    fill_color: Color32,
+) -> Result<Mesh, TessellationError> {
+    let mut builder = Path::builder();
+
+    builder.add_polygon(Polygon {
+        points: exterior,
+        closed: true,
+    });
+
+    for interior in interiors {
+        builder.add_polygon(Polygon {
+            points: interior,
+            closed: true,
+        });
+    }
+
+    let mut buffers: VertexBuffers<Vertex, u32> = VertexBuffers::new();
+
+    FillTessellator::new().tessellate_path(
+        &builder.build(),
+        &FillOptions::default(),
+        &mut BuffersBuilder::new(&mut buffers, |vertex: FillVertex| {
+            let pos = vertex.position();
+            Vertex {
+                pos: pos2(pos.x, pos.y),
+                uv: WHITE_UV,
+                color: fill_color,
+            }
+        }),
+    )?;
+
+    Ok(Mesh {
+        indices: buffers.indices,
+        vertices: buffers.vertices,
+        ..Default::default()
+    })
+}
+
+/// Convert list of `geo_types::Coord` to Lyon's `Point`s.
+fn lyon_points(points: &[Coord<f32>]) -> Vec<Point<f32>> {
+    points.iter().map(|p| point(p.x, p.y)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn dash_polyline_without_pattern_keeps_a_single_segment() {
+        let points = vec![pos2(0.0, 0.0), pos2(10.0, 0.0)];
+        let segments = dash_polyline(&points, &[], 1.0);
+        assert_eq!(segments, vec![points]);
+    }
+
+    #[test]
+    fn dash_polyline_splits_dashes_and_gaps() {
+        // Pattern [2, 1] at width 1.0 means a 2-unit dash followed by a 1-unit gap,
+        // repeating. Over a 10-unit straight line that's dash/gap/dash/gap/dash/gap...
+        let points = vec![pos2(0.0, 0.0), pos2(9.0, 0.0)];
+        let segments = dash_polyline(&points, &[2.0, 1.0], 1.0);
+
+        assert_eq!(
+            segments,
+            vec![
+                vec![pos2(0.0, 0.0), pos2(2.0, 0.0)],
+                vec![pos2(3.0, 0.0), pos2(5.0, 0.0)],
+                vec![pos2(6.0, 0.0), pos2(8.0, 0.0)],
+                vec![pos2(9.0, 0.0)],
+            ]
+            .into_iter()
+            .filter(|segment: &Vec<egui::Pos2>| segment.len() >= 2)
+            .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn dash_polyline_pattern_scales_with_line_width() {
+        let points = vec![pos2(0.0, 0.0), pos2(4.0, 0.0)];
+        // width 2.0 turns the [2, 1] pattern into 4-unit dash, 2-unit gap.
+        let segments = dash_polyline(&points, &[2.0, 1.0], 2.0);
+        assert_eq!(segments, vec![vec![pos2(0.0, 0.0), pos2(4.0, 0.0)]]);
+    }
+
+    fn label(geometry: Geometry<f32>) -> Vec<ShapeOrText> {
+        let context = Context::new(
+            geometry_type_to_str(&geometry).to_string(),
+            HashMap::from([("name".to_string(), serde_json::Value::from("Śnieżka"))]),
+            12,
+        );
+
+        let layout = Layout {
+            text_field: Some(crate::style::json!(["get", "name"])),
+            text_size: None,
+        };
+
+        let mut shapes = Vec::new();
+        render_symbol(&geometry, &context, &mut shapes, &layout, &None).unwrap();
+        shapes
+    }
+
+    fn texts(shapes: &[ShapeOrText]) -> Vec<&str> {
+        shapes
+            .iter()
+            .filter_map(|shape| match shape {
+                ShapeOrText::Text(text) => Some(text.text.as_str()),
+                ShapeOrText::Shape(_) => None,
+            })
+            .collect()
+    }
+
+    /// MVT hands over `MultiPoint`, GeoJSON a plain `Point`, and both need labelling.
+    #[test]
+    fn points_are_labelled_whether_they_come_singly_or_not() {
+        let point = geo_types::Point::new(1.0, 2.0);
+
+        assert_eq!(texts(&label(Geometry::Point(point))), ["Śnieżka"]);
+        assert_eq!(
+            texts(&label(Geometry::MultiPoint(
+                vec![point, geo_types::Point::new(3.0, 4.0)].into()
+            ))),
+            ["Śnieżka", "Śnieżka"]
+        );
+    }
+
+    #[test]
+    fn line_strings_are_labelled_whether_they_come_singly_or_not() {
+        let line_string =
+            geo_types::LineString::from(vec![(0.0f32, 0.0f32), (10.0, 0.0), (10.0, 10.0)]);
+
+        assert_eq!(
+            texts(&label(Geometry::LineString(line_string.clone()))),
+            ["Śnieżka"]
+        );
+        assert_eq!(
+            texts(&label(Geometry::MultiLineString(
+                geo_types::MultiLineString::new(vec![line_string.clone(), line_string])
+            ))),
+            ["Śnieżka", "Śnieżka"]
+        );
+    }
+
+    /// Labels are placed on the geometry, not at the origin.
+    #[test]
+    fn a_point_label_lands_on_the_point() {
+        let shapes = label(Geometry::Point(geo_types::Point::new(1.0, 2.0)));
+
+        match shapes.as_slice() {
+            [ShapeOrText::Text(text)] => assert_eq!(text.position, pos2(1.0, 2.0)),
+            other => panic!("expected a single label, got {other:?}"),
+        }
+    }
+}

--- a/walkers/src/text.rs
+++ b/walkers/src/text.rs
@@ -1,4 +1,4 @@
-use egui::{Color32, Pos2, Vec2, vec2};
+use egui::{Color32, Pos2, Shape, Vec2, vec2};
 use geo::{BoundingRect, Coord, Intersects, LineString, Polygon};
 
 #[derive(Debug, Clone)]
@@ -102,5 +102,40 @@ impl OccupiedAreas {
         } else {
             false
         }
+    }
+}
+
+/// Lay the text out, unless it would land on an area which is already taken.
+pub fn draw_text(
+    text: Text,
+    ctx: &egui::Context,
+    occupied_text_areas: &mut OccupiedAreas,
+) -> Shape {
+    use egui::epaint::TextShape;
+
+    let mut layout_job = egui::text::LayoutJob::default();
+
+    layout_job.append(
+        &text.text,
+        0.0,
+        egui::TextFormat {
+            font_id: egui::FontId::proportional(text.font_size),
+            color: text.text_color,
+            background: text.background_color,
+            ..Default::default()
+        },
+    );
+
+    let galley = ctx.fonts_mut(|fonts| fonts.layout_job(layout_job));
+
+    let area = OrientedRect::new(text.position, text.angle, galley.size());
+    let top_left = area.top_left();
+
+    if occupied_text_areas.try_occupy(area) {
+        TextShape::new(top_left, galley, text.text_color)
+            .with_angle(text.angle)
+            .into()
+    } else {
+        Shape::Noop
     }
 }

--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "mvt")]
-use crate::mvt::{self, ShapeOrText};
+use crate::mvt;
+#[cfg(feature = "mvt")]
+use crate::render::{self, ShapeOrText};
 
 use egui::{Color32, Context, Mesh, Rect, Vec2, pos2};
 use egui::{ColorImage, TextureHandle};
@@ -171,7 +173,7 @@ impl Tile {
                 // ...and then it can be clipped to the `rect`.
                 let painter = painter.with_clip_rect(rect);
 
-                painter.extend(mvt::resolve_text(
+                painter.extend(render::resolve_text(
                     mvt::transformed(shapes, full_rect),
                     painter.ctx(),
                 ));


### PR DESCRIPTION
Two thirds of `mvt.rs` was not about Mapbox Vector Tiles. Drawing a geometry the way the style says to is the same job whether the geometry arrived in a vector tile, a GeoJSON file or a KML one, and `geojson.rs` already imported `render_line` and friends out of a module named after a format it does not use.

`resolve_text` showed the seam most clearly. It belongs with `Text` and `OccupiedAreas` in `text.rs`, but it had to live in `mvt.rs` to reach `ShapeOrText`, which is to say a generic function was dragged into the MVT module by a dependency pointing the wrong way. `draw_text` lands in `text.rs` now, and `resolve_text` sits next to the type it consumes.

What is left in `mvt.rs` decodes tiles: reading features out of a layer, turning MVT property values into JSON ones, and the extent that tile coordinates are expressed in. Its `Error` loses the tessellation variant, which is the renderer's to raise, along with three variants nothing has been constructing.

Nothing about the public API moves - the crate root re-exports the same names from the new module - so `walkers_extras` compiles untouched, which is the evidence that this was only a move.

 * [ ] Map is displaying and reacting to input correctly, both natively and on the web.
 * [ ] `CHANGELOG.md` was updated with relevant information (or the change was purely internal).
