### PR TITLE
Bring the window shadows closer in wanderers

### DIFF
--- a/wanderers/src/main.rs
+++ b/wanderers/src/main.rs
@@ -1,5 +1,6 @@
 mod app;
 mod journal;
+mod style;
 
 use app::Wanderers;
 
@@ -27,6 +28,9 @@ fn main() -> Result<(), eframe::Error> {
     eframe::run_native(
         "wanderers",
         options,
-        Box::new(|cc| Ok(Box::new(Wanderers::new(cc.egui_ctx.to_owned(), path)))),
+        Box::new(|cc| {
+            style::apply(&cc.egui_ctx);
+            Ok(Box::new(Wanderers::new(cc.egui_ctx.to_owned(), path)))
+        }),
     )
 }

--- a/wanderers/src/style.rs
+++ b/wanderers/src/style.rs
@@ -1,0 +1,13 @@
+//! How the app itself looks.
+//!
+//! Not to be confused with [`walkers::Style`], which is about the look of the map.
+
+use egui::Context;
+
+/// Applied once, when the app starts.
+pub fn apply(ctx: &Context) {
+    ctx.all_styles_mut(|style| {
+        style.visuals.window_shadow.offset = [2, 3];
+        style.visuals.popup_shadow.offset = [1, 2];
+    });
+}


### PR DESCRIPTION
The default offset throws them far enough to read as a smudge on the map. New `style` module for the app's own look, so there is somewhere to put the next tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)