### PR TITLE
Give wanderers a vector map style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 * Fix tile sources with tiles smaller than 256px being rendered as if they were 256px.
 * `GeoJsonLayer` now renders `symbol` layers, including their text labels.
 * Fix `fill` layers not rendering features made of a single polygon.
+* `source_layer` is now a `SourceLayer`, which can name several layers of a vector tile instead
+  of one. It still takes a plain name, and an empty one still matches all of them.
 
 ## 0.58.0
 

--- a/demo/src/kml.rs
+++ b/demo/src/kml.rs
@@ -6,7 +6,7 @@ pub fn poland_borders() -> KmlLayer {
     let style = Style {
         layers: vec![Layer::Line {
             // TODO: Actually, it does not matter.
-            source_layer: "borders".to_string(),
+            source_layer: "borders".into(),
             filter: None,
             paint: Paint {
                 line_color: Some(Color(json!("#ff0000"))),
@@ -24,7 +24,7 @@ pub fn poland_borders() -> KmlLayer {
 pub fn outgym_umea_layer() -> KmlLayer {
     let style = Style {
         layers: vec![Layer::Circle {
-            source_layer: "".to_string(),
+            source_layer: "".into(),
             filter: None,
         }],
     };

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -157,7 +157,7 @@ fn hiking_style() -> Style {
     Style {
         layers: vec![
             Layer::Line {
-                source_layer: "".to_string(),
+                source_layer: "".into(),
                 filter: Some(Filter(json!([
                     "any",
                     ["==", ["get", "colour"], "red"],
@@ -171,7 +171,7 @@ fn hiking_style() -> Style {
                 },
             },
             Layer::Line {
-                source_layer: "".to_string(),
+                source_layer: "".into(),
                 filter: Some(Filter(json!([
                     "any",
                     ["==", ["get", "colour"], "yellow"],
@@ -184,7 +184,7 @@ fn hiking_style() -> Style {
                 },
             },
             Layer::Line {
-                source_layer: "".to_string(),
+                source_layer: "".into(),
                 filter: Some(Filter(json!(["==", ["get", "colour"], "red"]))),
                 paint: Paint {
                     line_color: Some(Color(json!("#7b0000"))),
@@ -193,7 +193,7 @@ fn hiking_style() -> Style {
                 },
             },
             Layer::Line {
-                source_layer: "".to_string(),
+                source_layer: "".into(),
                 filter: Some(Filter(json!(["==", ["get", "colour"], "blue"]))),
                 paint: Paint {
                     line_color: Some(Color(json!("#0028ac"))),
@@ -202,7 +202,7 @@ fn hiking_style() -> Style {
                 },
             },
             Layer::Line {
-                source_layer: "".to_string(),
+                source_layer: "".into(),
                 filter: Some(Filter(json!(["==", ["get", "colour"], "green"]))),
                 paint: Paint {
                     line_color: Some(Color(json!("#005d09"))),
@@ -211,7 +211,7 @@ fn hiking_style() -> Style {
                 },
             },
             Layer::Line {
-                source_layer: "".to_string(),
+                source_layer: "".into(),
                 filter: Some(Filter(json!(["==", ["get", "colour"], "yellow"]))),
                 paint: Paint {
                     line_color: Some(Color(json!("#bbbb00"))),
@@ -220,7 +220,7 @@ fn hiking_style() -> Style {
                 },
             },
             Layer::Line {
-                source_layer: "".to_string(),
+                source_layer: "".into(),
                 filter: Some(Filter(json!(["==", ["get", "colour"], "black"]))),
                 paint: Paint {
                     line_color: Some(Color(json!("#000000"))),
@@ -229,7 +229,7 @@ fn hiking_style() -> Style {
                 },
             },
             Layer::Symbol {
-                source_layer: "".to_string(),
+                source_layer: "".into(),
                 filter: Some(Filter(json!(["==", ["get", "natural"], "peak"]))),
                 layout: Layout {
                     text_field: Some(json!(["get", "name"])),

--- a/walkers/src/lib.rs
+++ b/walkers/src/lib.rs
@@ -52,7 +52,7 @@ pub use position::{Position, lat_lon, lon_lat};
 pub use projector::Projector;
 pub use style::Style;
 #[cfg(feature = "mvt")]
-pub use style::{Color, Dasharray, Filter, Float, Layer, Layout, Paint, Value, json};
+pub use style::{Color, Dasharray, Filter, Float, Layer, Layout, Paint, SourceLayer, Value, json};
 pub use tiles::{Tile, TileId, TilePiece, Tiles};
 pub use zoom::InvalidZoom;
 

--- a/walkers/src/mvt.rs
+++ b/walkers/src/mvt.rs
@@ -10,17 +10,13 @@ use serde_json::{Number, Value as JsonValue};
 use crate::{
     expression::Context,
     render::{self, Geometry, ShapeOrText},
-    style::{Filter, Layer, Style},
+    style::{Filter, Layer, SourceLayer, Style},
 };
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Decoding MVT failed: {0}.")]
     Mvt(String),
-    #[error("Layer not found: {0}. Available layers: {1:?}")]
-    LayerNotFound(String, Vec<String>),
-    #[error("Unsupported layer extent: {0}")]
-    UnsupportedLayerExtent(String),
 }
 
 /// Custom conversion because mvt_reader::error::Error is not Send.
@@ -127,24 +123,35 @@ pub fn transformed(shapes: &[ShapeOrText], rect: egui::Rect) -> Vec<ShapeOrText>
 fn get_layer_features(
     reader: &Reader,
     zoom: u8,
-    name: &str,
+    source_layer: &SourceLayer,
     filter: Option<&Filter>,
 ) -> Result<impl Iterator<Item = (Geometry<f32>, Context)>, Error> {
-    // An empty source layer matches features from all layers. Intended for sparse
-    // overlay tiles; pointing dense basemap rules at "" would scan every layer.
-    let raw = if name.is_empty() {
-        reader
-            .get_layer_metadata()?
-            .into_iter()
-            .filter(|layer| layer.extent == ONLY_SUPPORTED_EXTENT)
-            .flat_map(|layer| reader.get_features(layer.layer_index).unwrap_or_default())
-            .collect()
-    } else if let Ok(layer_index) = find_layer(reader, name) {
-        reader.get_features(layer_index)?
-    } else {
-        warn!("Source layer '{name}' not found. Skipping.");
-        Vec::new()
-    };
+    let mut matched = 0usize;
+    let mut raw = Vec::new();
+
+    for layer in reader.get_layer_metadata()? {
+        if !source_layer.matches(&layer.name) {
+            continue;
+        }
+
+        matched += 1;
+
+        if layer.extent != ONLY_SUPPORTED_EXTENT {
+            warn!(
+                "Unsupported extent in source layer '{}'. Skipping.",
+                layer.name
+            );
+            continue;
+        }
+
+        raw.extend(reader.get_features(layer.layer_index).unwrap_or_default());
+    }
+
+    // Asking for everything and finding nothing is a tile without features, but asking for a
+    // layer by name and not finding it usually means the style does not fit the schema.
+    if matched == 0 && !source_layer.is_all() {
+        warn!("Source layer {source_layer} not found. Skipping.");
+    }
 
     let features = raw.into_iter().filter_map(move |feature| {
         let context = Context::new(
@@ -189,24 +196,4 @@ fn mvt_value_to_json_value(value: &Value) -> JsonValue {
             JsonValue::Null
         }
     }
-}
-
-fn find_layer(data: &Reader, name: &str) -> Result<usize, Error> {
-    let layer = data
-        .get_layer_metadata()?
-        .into_iter()
-        .find(|layer| layer.name == name);
-
-    let Some(layer) = layer else {
-        return Err(Error::LayerNotFound(
-            name.to_string(),
-            data.get_layer_names()?,
-        ));
-    };
-
-    if layer.extent != ONLY_SUPPORTED_EXTENT {
-        return Err(Error::UnsupportedLayerExtent(name.to_string()));
-    }
-
-    Ok(layer.layer_index)
 }

--- a/walkers/src/style.rs
+++ b/walkers/src/style.rs
@@ -51,6 +51,69 @@ impl Style {
     }
 }
 
+/// Which layer, or layers, of a vector tile a style layer draws from.
+///
+/// MapLibre names exactly one. Walkers also takes a list, for schemas which spread one concept
+/// over several layers, and treats an empty name or an empty list as "all of them".
+#[derive(Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum SourceLayer {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl SourceLayer {
+    /// Whether a tile layer of this name should be drawn.
+    pub fn matches(&self, name: &str) -> bool {
+        match self {
+            SourceLayer::One(one) => one.is_empty() || one == name,
+            SourceLayer::Many(many) => many.is_empty() || many.iter().any(|it| it == name),
+        }
+    }
+
+    /// Matching everything is intended for sparse overlay tiles. Pointing dense basemap rules
+    /// at it would scan every layer of every tile.
+    pub fn is_all(&self) -> bool {
+        match self {
+            SourceLayer::One(one) => one.is_empty(),
+            SourceLayer::Many(many) => many.is_empty(),
+        }
+    }
+}
+
+impl std::fmt::Display for SourceLayer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SourceLayer::One(one) => write!(f, "'{one}'"),
+            SourceLayer::Many(many) => write!(f, "{many:?}"),
+        }
+    }
+}
+
+impl From<&str> for SourceLayer {
+    fn from(name: &str) -> Self {
+        SourceLayer::One(name.to_owned())
+    }
+}
+
+impl From<String> for SourceLayer {
+    fn from(name: String) -> Self {
+        SourceLayer::One(name)
+    }
+}
+
+impl<const N: usize> From<[&str; N]> for SourceLayer {
+    fn from(names: [&str; N]) -> Self {
+        SourceLayer::Many(names.iter().map(|name| (*name).to_owned()).collect())
+    }
+}
+
+impl From<&[&str]> for SourceLayer {
+    fn from(names: &[&str]) -> Self {
+        SourceLayer::Many(names.iter().map(|name| (*name).to_owned()).collect())
+    }
+}
+
 #[derive(Deserialize, Debug)]
 #[serde(tag = "type", rename_all = "kebab-case")]
 pub enum Layer {
@@ -59,25 +122,25 @@ pub enum Layer {
     },
     #[serde(rename_all = "kebab-case")]
     Fill {
-        source_layer: String,
+        source_layer: SourceLayer,
         filter: Option<Filter>,
         paint: Paint,
     },
     #[serde(rename_all = "kebab-case")]
     Line {
-        source_layer: String,
+        source_layer: SourceLayer,
         filter: Option<Filter>,
         paint: Paint,
     },
     #[serde(rename_all = "kebab-case")]
     Symbol {
-        source_layer: String,
+        source_layer: SourceLayer,
         filter: Option<Filter>,
         layout: Layout,
         paint: Option<Paint>,
     },
     Circle {
-        source_layer: String,
+        source_layer: SourceLayer,
         filter: Option<Filter>,
     },
     Raster,
@@ -239,5 +302,46 @@ mod tests {
     fn test_style_parsing() {
         Style::protomaps_dark();
         Style::protomaps_light();
+    }
+}
+
+#[cfg(test)]
+mod source_layer_tests {
+    use super::*;
+
+    /// A plain name is what every MapLibre style writes, and must keep working.
+    #[test]
+    fn one_name_matches_only_itself() {
+        let one: SourceLayer = "roads".into();
+        assert!(one.matches("roads"));
+        assert!(!one.matches("transportation"));
+        assert!(!one.is_all());
+    }
+
+    #[test]
+    fn a_list_matches_any_of_its_names() {
+        let many: SourceLayer = ["landcover", "landuse", "park"].into();
+        assert!(many.matches("landcover"));
+        assert!(many.matches("park"));
+        assert!(!many.matches("roads"));
+        assert!(!many.is_all());
+    }
+
+    /// Emptiness has meant "every layer of the tile" since before this type existed.
+    #[test]
+    fn emptiness_matches_everything() {
+        for empty in [SourceLayer::from(""), SourceLayer::Many(Vec::new())] {
+            assert!(empty.matches("anything"));
+            assert!(empty.is_all());
+        }
+    }
+
+    #[test]
+    fn both_forms_deserialize() {
+        let one: SourceLayer = serde_json::from_str(r#""roads""#).unwrap();
+        assert!(one.matches("roads"));
+
+        let many: SourceLayer = serde_json::from_str(r#"["roads", "transportation"]"#).unwrap();
+        assert!(many.matches("transportation"));
     }
 }

--- a/wanderers/Cargo.toml
+++ b/wanderers/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-walkers = { workspace = true, features = ["mvt"] }
+walkers = { workspace = true, features = ["mvt", "pmtiles"] }
 walkers_extras.workspace = true
 eframe.workspace = true
 egui.workspace = true

--- a/wanderers/src/app.rs
+++ b/wanderers/src/app.rs
@@ -1,13 +1,14 @@
 use std::path::PathBuf;
 
 use egui::{Align2, Color32, ComboBox, Image, Key, PointerButton, RichText, Ui, Window};
-use walkers::{HttpOptions, HttpTiles, Map, MapMemory, Position, Style, Tiles, lon_lat, sources};
+use walkers::{HttpOptions, HttpTiles, Map, MapMemory, PmTiles, Position, Tiles, lon_lat, sources};
 use walkers_extras::{
     GroupedPlaces, LabeledSymbol, LabeledSymbolGroup, LabeledSymbolGroupStyle, LabeledSymbolStyle,
     Symbol,
 };
 
 use crate::journal::{self, Journal, Place};
+use crate::map_style::{self, Shade};
 
 /// Where the map is centered when the app starts, until the journal has a say in it.
 fn home() -> Position {
@@ -30,45 +31,111 @@ fn cache_dir() -> Option<PathBuf> {
 }
 
 /// Map the places are drawn on top of.
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, PartialEq)]
 enum Basemap {
     OpenStreetMap,
-    OpenFreeMap,
+
+    /// Vector tiles, so the same map comes in either shade.
+    OpenFreeMap(Shade),
 
     /// Poland only, but it has aerial imagery, which the other two do not.
     Geoportal,
+
+    /// A `.pmtiles` file sitting next to the app, so the map works without a network.
+    Protomaps(PathBuf, Shade),
 }
 
 impl Basemap {
-    /// All of them, in the order they are offered.
-    const ALL: [Basemap; 3] = [
-        Basemap::OpenStreetMap,
-        Basemap::OpenFreeMap,
-        Basemap::Geoportal,
-    ];
+    /// In the order they are offered. Protomaps only shows up when there is a file for it.
+    fn all() -> Vec<Basemap> {
+        let mut all = vec![Basemap::OpenStreetMap];
+        all.extend(Shade::ALL.map(Basemap::OpenFreeMap));
+        all.push(Basemap::Geoportal);
 
-    fn name(self) -> &'static str {
+        for path in pmtiles_files() {
+            all.extend(Shade::ALL.map(|shade| Basemap::Protomaps(path.to_owned(), shade)));
+        }
+
+        all
+    }
+
+    fn name(&self) -> String {
         match self {
-            Basemap::OpenStreetMap => "OpenStreetMap",
-            Basemap::OpenFreeMap => "OpenFreeMap",
-            Basemap::Geoportal => "Geoportal",
+            Basemap::OpenStreetMap => "OpenStreetMap".to_owned(),
+            Basemap::OpenFreeMap(shade) => format!("OpenFreeMap ({})", shade.name()),
+            Basemap::Geoportal => "Geoportal".to_owned(),
+            Basemap::Protomaps(path, shade) => format!(
+                "{} ({})",
+                path.file_stem().unwrap_or_default().to_string_lossy(),
+                shade.name()
+            ),
         }
     }
 
-    fn tiles(self, egui_ctx: egui::Context) -> HttpTiles {
+    fn tiles(&self, egui_ctx: egui::Context) -> Basetiles {
         match self {
-            Basemap::OpenStreetMap => {
-                HttpTiles::with_options(sources::OpenStreetMap, http_options(), egui_ctx)
-            }
-            Basemap::OpenFreeMap => HttpTiles::with_options_and_style(
-                sources::OpenFreeMap,
+            Basemap::OpenStreetMap => Basetiles::Http(Box::new(HttpTiles::with_options(
+                sources::OpenStreetMap,
                 http_options(),
-                Style::openfreemap_bright(),
                 egui_ctx,
-            ),
-            Basemap::Geoportal => {
-                HttpTiles::with_options(sources::Geoportal, http_options(), egui_ctx)
+            ))),
+            Basemap::OpenFreeMap(shade) => {
+                Basetiles::Http(Box::new(HttpTiles::with_options_and_style(
+                    sources::OpenFreeMap,
+                    http_options(),
+                    map_style::style(*shade, map_style::OPENMAPTILES),
+                    egui_ctx,
+                )))
             }
+            Basemap::Geoportal => Basetiles::Http(Box::new(HttpTiles::with_options(
+                sources::Geoportal,
+                http_options(),
+                egui_ctx,
+            ))),
+            Basemap::Protomaps(path, shade) => Basetiles::PmTiles(Box::new(PmTiles::with_style(
+                path,
+                map_style::style(*shade, map_style::PROTOMAPS),
+                egui_ctx,
+            ))),
+        }
+    }
+}
+
+/// `.pmtiles` files in the current directory. See `just protomaps-dolnoslaskie` in `walkers`
+/// for one way of getting one.
+fn pmtiles_files() -> Vec<PathBuf> {
+    let Ok(dir) = std::fs::read_dir(".") else {
+        return Vec::new();
+    };
+
+    let mut files: Vec<_> = dir
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+            (path.extension()?.to_str()? == "pmtiles").then_some(path)
+        })
+        .collect();
+    files.sort();
+    files
+}
+
+/// Tiles either come over HTTP or out of a local file.
+enum Basetiles {
+    Http(Box<HttpTiles>),
+    PmTiles(Box<PmTiles>),
+}
+
+impl Basetiles {
+    fn as_mut(&mut self) -> &mut dyn Tiles {
+        match self {
+            Basetiles::Http(tiles) => tiles.as_mut(),
+            Basetiles::PmTiles(tiles) => tiles.as_mut(),
+        }
+    }
+
+    fn attribution(&self) -> sources::Attribution {
+        match self {
+            Basetiles::Http(tiles) => tiles.attribution(),
+            Basetiles::PmTiles(tiles) => tiles.attribution(),
         }
     }
 }
@@ -91,7 +158,7 @@ pub struct Wanderers {
     egui_ctx: egui::Context,
 
     basemap: Basemap,
-    tiles: HttpTiles,
+    tiles: Basetiles,
     map_memory: MapMemory,
     journal: Result<Journal, journal::Error>,
     new_place: Option<NewPlace>,
@@ -118,8 +185,8 @@ impl Wanderers {
     /// Only one basemap is kept around at a time. Switching back and forth costs a rebuild,
     /// but the tiles themselves are cached on disk, so it is not a re-download.
     fn switch_basemap_to(&mut self, basemap: Basemap) {
-        self.basemap = basemap;
         self.tiles = basemap.tiles(self.egui_ctx.to_owned());
+        self.basemap = basemap;
     }
 
     /// Every addition is written out right away, so that there is no unsaved journal to lose.
@@ -142,7 +209,7 @@ impl eframe::App for Wanderers {
         let pending = self.new_place.as_ref().map(|new_place| new_place.position);
 
         let mut map =
-            Map::new(Some(&mut self.tiles), &mut self.map_memory, home()).zoom_with_ctrl(false);
+            Map::new(Some(self.tiles.as_mut()), &mut self.map_memory, home()).zoom_with_ctrl(false);
 
         if let Ok(journal) = &self.journal {
             map = map.with_plugin(places(&journal.places));
@@ -193,7 +260,7 @@ impl eframe::App for Wanderers {
             }
         }
 
-        if let Some(chosen) = basemap(ui, self.basemap) {
+        if let Some(chosen) = basemap(ui, &self.basemap) {
             self.switch_basemap_to(chosen);
         }
 
@@ -274,8 +341,8 @@ fn places(places: &[journal::Place]) -> impl walkers::Plugin {
 }
 
 /// Lets one swap the map the places are drawn on. Returns the pick, if it changed.
-fn basemap(ui: &Ui, current: Basemap) -> Option<Basemap> {
-    let mut chosen = current;
+fn basemap(ui: &Ui, current: &Basemap) -> Option<Basemap> {
+    let mut chosen = current.to_owned();
 
     Window::new("Basemap")
         .collapsible(false)
@@ -286,13 +353,14 @@ fn basemap(ui: &Ui, current: Basemap) -> Option<Basemap> {
             ComboBox::from_id_salt("basemap")
                 .selected_text(current.name())
                 .show_ui(ui, |ui| {
-                    for basemap in Basemap::ALL {
-                        ui.selectable_value(&mut chosen, basemap, basemap.name());
+                    for basemap in Basemap::all() {
+                        let name = basemap.name();
+                        ui.selectable_value(&mut chosen, basemap, name);
                     }
                 });
         });
 
-    (chosen != current).then_some(chosen)
+    (&chosen != current).then_some(chosen)
 }
 
 /// Buttons to zoom in and out, for when there is no scroll wheel around.
@@ -358,4 +426,33 @@ fn acknowledge(ui: &Ui, attribution: sources::Attribution) {
                 ui.hyperlink_to(attribution.text, attribution.url);
             });
         });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Vector maps come in both shades, and each is its own entry in the picker.
+    #[test]
+    fn every_shade_of_a_vector_basemap_is_offered_separately() {
+        let names: Vec<_> = Basemap::all().iter().map(Basemap::name).collect();
+
+        assert!(names.contains(&"OpenFreeMap (light)".to_owned()));
+        assert!(names.contains(&"OpenFreeMap (dark)".to_owned()));
+
+        // Raster ones have nothing to shade, so they stay single.
+        assert_eq!(
+            names.iter().filter(|name| *name == "OpenStreetMap").count(),
+            1
+        );
+    }
+
+    /// Two entries which look the same in the picker would be indistinguishable to click.
+    #[test]
+    fn basemap_names_are_unique() {
+        let names: Vec<_> = Basemap::all().iter().map(Basemap::name).collect();
+        let unique: std::collections::HashSet<_> = names.iter().collect();
+
+        assert_eq!(names.len(), unique.len(), "duplicate names in {names:?}");
+    }
 }

--- a/wanderers/src/main.rs
+++ b/wanderers/src/main.rs
@@ -1,5 +1,6 @@
 mod app;
 mod journal;
+mod map_style;
 
 use app::Wanderers;
 

--- a/wanderers/src/map_style.rs
+++ b/wanderers/src/map_style.rs
@@ -1,0 +1,1411 @@
+use walkers::{Color, Dasharray, Filter, Float, Layer, Layout, Paint, Style, Value, json};
+
+/// Which vector tile schema the tiles follow.
+///
+/// Protomaps and OpenMapTiles carry the same world under different names, and the names are
+/// the only thing a filter cannot reach: `source_layer` picks the tile layer before there is
+/// any feature to test. Everything else - property keys, value vocabularies - is handled in
+/// the filters themselves.
+#[derive(Clone, Copy)]
+pub struct Schema {
+    earth: &'static str,
+    landuse: &'static str,
+    water: &'static str,
+    waterway: &'static str,
+    roads: &'static str,
+    road_labels: &'static str,
+    buildings: &'static str,
+    places: &'static str,
+    pois: &'static str,
+    boundaries: &'static str,
+    kind: &'static str,
+    kind_detail: &'static str,
+    place_rank: &'static str,
+    brunnel: Option<&'static str>,
+    link: &'static str,
+}
+
+/// Served by Protomaps `.pmtiles`.
+pub const PROTOMAPS: Schema = Schema {
+    earth: "earth",
+    landuse: "landuse",
+    water: "water",
+    waterway: "water",
+    roads: "roads",
+    road_labels: "roads",
+    buildings: "buildings",
+    places: "places",
+    pois: "pois",
+    boundaries: "boundaries",
+    kind: "kind",
+    kind_detail: "kind_detail",
+    place_rank: "population_rank",
+    brunnel: None,
+    link: "is_link",
+};
+
+/// Served by OpenFreeMap. There is no land polygon here - the background stands in for one -
+/// so `earth` is empty and the layers asking for it are dropped.
+pub const OPENMAPTILES: Schema = Schema {
+    earth: "",
+    landuse: "landcover",
+    water: "water",
+    waterway: "waterway",
+    roads: "transportation",
+    road_labels: "transportation_name",
+    buildings: "building",
+    places: "place",
+    pois: "poi",
+    boundaries: "boundary",
+    kind: "class",
+    kind_detail: "subclass",
+    place_rank: "rank",
+    brunnel: Some("brunnel"),
+    link: "ramp",
+};
+
+/// A road which bridges or tunnels rather than lying on the ground.
+#[derive(Clone, Copy)]
+pub enum Brunnel {
+    Tunnel,
+    Bridge,
+}
+
+impl Brunnel {
+    /// Protomaps flags it with a property of its own, OpenMapTiles with a value.
+    fn protomaps(self) -> &'static str {
+        match self {
+            Brunnel::Tunnel => "is_tunnel",
+            Brunnel::Bridge => "is_bridge",
+        }
+    }
+
+    fn openmaptiles(self) -> &'static str {
+        match self {
+            Brunnel::Tunnel => "tunnel",
+            Brunnel::Bridge => "bridge",
+        }
+    }
+}
+
+impl Schema {
+    fn is(&self, what: Brunnel) -> Value {
+        match self.brunnel {
+            Some(key) => json!(["==", key, what.openmaptiles()]),
+            None => json!(["has", what.protomaps()]),
+        }
+    }
+
+    fn is_not(&self, what: Brunnel) -> Value {
+        match self.brunnel {
+            Some(key) => json!(["!=", key, what.openmaptiles()]),
+            None => json!(["!has", what.protomaps()]),
+        }
+    }
+
+    fn is_link(&self) -> Value {
+        match self.brunnel {
+            Some(_) => json!(["==", self.link, 1]),
+            None => json!(["has", self.link]),
+        }
+    }
+
+    fn is_not_link(&self) -> Value {
+        match self.brunnel {
+            Some(_) => json!(["!=", self.link, 1]),
+            None => json!(["!has", self.link]),
+        }
+    }
+}
+
+fn linear_zoom_interpolation(stops: &[(f64, f64)]) -> Float {
+    let mut expr = vec![json!("interpolate"), json!(["linear"]), json!(["zoom"])];
+    for &(zoom, value) in stops {
+        expr.push(json!(zoom));
+        expr.push(json!(value));
+    }
+    Float(json!(expr))
+}
+
+struct Palette {
+    background: &'static str,
+    rail: &'static str,
+    rail_tie: &'static str,
+    forest: &'static str,
+    urban_green: &'static str,
+    pier: &'static str,
+    tunnel_casing: &'static str,
+    casing: &'static str,
+    landuse_dark: &'static str,
+    bridge: &'static str,
+    structure: &'static str,
+    muted: &'static str,
+    highway: &'static str,
+    road: &'static str,
+    label_muted: &'static str,
+    major_road_border: &'static str,
+    label: &'static str,
+    locality_text: &'static str,
+    water: &'static str,
+    station: &'static str,
+}
+
+const DARK: Palette = Palette {
+    background: "#000000",
+    rail_tie: "#bfbfbf",
+    rail: "#000000",
+    forest: "#061009",
+    urban_green: "#000c00",
+    pier: "#0a0a0a",
+    tunnel_casing: "#101010",
+    casing: "#141414",
+    landuse_dark: "#191919",
+    bridge: "#1f1f1f",
+    structure: "#292929",
+    muted: "#333333",
+    highway: "#352121",
+    road: "#464646",
+    label_muted: "#5c5c5c",
+    major_road_border: "#696868",
+    label: "#707070",
+    locality_text: "#999999",
+    water: "#161e31",
+    station: "#7fb3d9",
+};
+
+const LIGHT: Palette = Palette {
+    background: "#f2f2f0",
+    rail_tie: "#000000",
+    //rail_tie: "#cccccc",
+    rail: "#ffffff",
+    forest: "#86a180",
+    urban_green: "#e2f0df",
+    pier: "#8c8c8c",
+    tunnel_casing: "#595959",
+    casing: "#ffffff",
+    landuse_dark: "#e0e0e0",
+    bridge: "#bfbfbf",
+    structure: "#d4d4d4",
+    muted: "#b3b3b3",
+    highway: "#bb5f5f",
+    road: "#4a4a4a",
+    label_muted: "#595959",
+    major_road_border: "#1e1e1e",
+    label: "#1f1f1f",
+    locality_text: "#1a1a1a",
+    water: "#88b2e2",
+    station: "#2b6ca3",
+};
+
+fn build(palette: &Palette, schema: Schema) -> Style {
+    let mut layers = vec![
+        // background
+        Layer::Background {
+            paint: Paint {
+                background_color: Some(Color(json!(palette.background))),
+                ..Default::default()
+            },
+        },
+        // earth
+        Layer::Fill {
+            source_layer: schema.earth.into(),
+            filter: Some(Filter(json!(["==", "$type", "Polygon"]))),
+            paint: Paint {
+                fill_color: Some(Color(json!(palette.background))),
+                ..Default::default()
+            },
+        },
+        // landuse_park
+        Layer::Fill {
+            source_layer: schema.landuse.into(),
+            filter: Some(Filter(json!([
+                "in",
+                schema.kind,
+                "national_park",
+                "park",
+                "public_park",
+                "nature_reserve",
+                "cemetery",
+                "nature_reserve",
+                "forest",
+                "golf_course",
+                "wood",
+                "farmland",
+                "scrub",
+                "grassland",
+                "grass",
+                "military",
+                "naval_base",
+                "airfield"
+            ]))),
+            paint: Paint {
+                fill_opacity: Some(Float(json!(0.5))),
+                fill_color: Some(Color(json!(palette.forest))),
+                ..Default::default()
+            },
+        },
+        // landuse_urban_green
+        Layer::Fill {
+            source_layer: schema.landuse.into(),
+            filter: Some(Filter(json!([
+                "in",
+                schema.kind,
+                "allotments",
+                "village_green",
+                "playground"
+            ]))),
+            paint: Paint {
+                fill_color: Some(Color(json!(palette.urban_green))),
+                ..Default::default()
+            },
+        },
+        // landuse_hospital
+        Layer::Fill {
+            source_layer: schema.landuse.into(),
+            filter: Some(Filter(json!(["==", schema.kind, "hospital"]))),
+            paint: Paint {
+                fill_color: Some(Color(json!(palette.landuse_dark))),
+                ..Default::default()
+            },
+        },
+        // landuse_industrial
+        //Layer::Fill {
+        //    source_layer: schema.landuse.into(),
+        //    filter: Some(Filter(json!(["==", schema.kind, "industrial"]))),
+        //    paint: Paint {
+        //        fill_color: Some(Color(json!(palette.tunnel_casing))),
+        //        ..Default::default()
+        //    },
+        //},
+        // landuse_beach
+        Layer::Fill {
+            source_layer: schema.landuse.into(),
+            filter: Some(Filter(json!(["in", schema.kind, "beach"]))),
+            paint: Paint {
+                fill_color: Some(Color(json!(palette.bridge))),
+                ..Default::default()
+            },
+        },
+        // landuse_zoo
+        Layer::Fill {
+            source_layer: schema.landuse.into(),
+            filter: Some(Filter(json!(["in", schema.kind, "zoo"]))),
+            paint: Paint {
+                fill_color: Some(Color(json!(palette.landuse_dark))),
+                ..Default::default()
+            },
+        },
+        // landuse_aerodrome
+        Layer::Fill {
+            source_layer: schema.landuse.into(),
+            filter: Some(Filter(json!(["in", schema.kind, "aerodrome"]))),
+            paint: Paint {
+                fill_color: Some(Color(json!(palette.landuse_dark))),
+                ..Default::default()
+            },
+        },
+        // roads_runway
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!(["==", schema.kind_detail, "runway"]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.muted))),
+                line_width: Some(linear_zoom_interpolation(&[
+                    (10.0, 0.0),
+                    (12.0, 4.0),
+                    (18.0, 30.0),
+                ])),
+                ..Default::default()
+            },
+        },
+        // roads_taxiway
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!(["==", schema.kind_detail, "taxiway"]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.muted))),
+                line_width: Some(linear_zoom_interpolation(&[
+                    (13.0, 0.0),
+                    (13.5, 1.0),
+                    (15.0, 6.0),
+                ])),
+                ..Default::default()
+            },
+        },
+        // landuse_runway
+        Layer::Fill {
+            source_layer: schema.landuse.into(),
+            filter: Some(Filter(json!(["in", schema.kind, "runway", "taxiway"]))),
+            paint: Paint {
+                fill_color: Some(Color(json!(palette.muted))),
+                ..Default::default()
+            },
+        },
+        // water
+        Layer::Fill {
+            source_layer: schema.water.into(),
+            filter: Some(Filter(json!(["==", "$type", "Polygon"]))),
+            paint: Paint {
+                fill_color: Some(Color(json!(palette.water))),
+                ..Default::default()
+            },
+        },
+        // water_stream
+        Layer::Line {
+            source_layer: schema.waterway.into(),
+            filter: Some(Filter(json!(["in", schema.kind, "stream"]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.water))),
+                ..Default::default()
+            },
+        },
+        // water_river
+        Layer::Line {
+            source_layer: schema.waterway.into(),
+            filter: Some(Filter(json!(["in", schema.kind, "river"]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.water))),
+                line_width: Some(linear_zoom_interpolation(&[
+                    (9.0, 0.0),
+                    (9.5, 1.0),
+                    (18.0, 12.0),
+                ])),
+                ..Default::default()
+            },
+        },
+        // landuse_pedestrian
+        Layer::Fill {
+            source_layer: schema.landuse.into(),
+            filter: Some(Filter(json!(["in", schema.kind, "pedestrian", "dam"]))),
+            paint: Paint {
+                fill_color: Some(Color(json!(palette.landuse_dark))),
+                ..Default::default()
+            },
+        },
+        // landuse_pier
+        Layer::Fill {
+            source_layer: schema.landuse.into(),
+            filter: Some(Filter(json!(["==", schema.kind, "pier"]))),
+            paint: Paint {
+                fill_color: Some(Color(json!(palette.pier))),
+                ..Default::default()
+            },
+        },
+        // roads_tunnels_other_casing
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is(Brunnel::Tunnel),
+                ["in", schema.kind, "other", "path", "service", "track"]
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.tunnel_casing))),
+                ..Default::default()
+            },
+        },
+        // roads_tunnels_minor_casing
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is(Brunnel::Tunnel),
+                ["in", schema.kind, "minor_road", "minor", "tertiary"]
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.tunnel_casing))),
+                line_dasharray: Some(Dasharray(json!([3, 2]))),
+                line_width: Some(linear_zoom_interpolation(&[(12.0, 0.0), (12.5, 1.0)])),
+                ..Default::default()
+            },
+        },
+        // roads_tunnels_link_casing
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is(Brunnel::Tunnel),
+                schema.is_link()
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.tunnel_casing))),
+                line_dasharray: Some(Dasharray(json!([3, 2]))),
+                line_width: Some(linear_zoom_interpolation(&[(12.0, 0.0), (12.5, 1.0)])),
+                ..Default::default()
+            },
+        },
+        // roads_tunnels_major_casing
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is_not(Brunnel::Tunnel),
+                schema.is_not(Brunnel::Bridge),
+                ["in", schema.kind, "major_road", "primary", "secondary"]
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.tunnel_casing))),
+                line_dasharray: Some(Dasharray(json!([3, 2]))),
+                line_width: Some(linear_zoom_interpolation(&[(9.0, 0.0), (9.5, 1.0)])),
+                ..Default::default()
+            },
+        },
+        // roads_tunnels_highway_casing
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is_not(Brunnel::Tunnel),
+                schema.is_not(Brunnel::Bridge),
+                ["in", schema.kind, "highway", "motorway", "trunk"],
+                schema.is_not_link()
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.tunnel_casing))),
+                line_dasharray: Some(Dasharray(json!([6, 0.5]))),
+                line_width: Some(linear_zoom_interpolation(&[
+                    (7.0, 0.0),
+                    (7.5, 1.5),
+                    (20.0, 22.5),
+                ])),
+                ..Default::default()
+            },
+        },
+        // roads_tunnels_other
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is(Brunnel::Tunnel),
+                ["in", schema.kind, "other", "path", "service", "track"]
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.structure))),
+                line_dasharray: Some(Dasharray(json!([4.5, 0.5]))),
+                line_width: Some(linear_zoom_interpolation(&[(14.0, 0.0), (20.0, 7.0)])),
+                ..Default::default()
+            },
+        },
+        // roads_tunnels_minor
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is(Brunnel::Tunnel),
+                ["in", schema.kind, "minor_road", "minor", "tertiary"]
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.structure))),
+                line_width: Some(linear_zoom_interpolation(&[
+                    (11.0, 0.0),
+                    (12.5, 0.5),
+                    (15.0, 2.0),
+                    (18.0, 11.0),
+                ])),
+                ..Default::default()
+            },
+        },
+        // roads_tunnels_link
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is(Brunnel::Tunnel),
+                schema.is_link()
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.structure))),
+                line_width: Some(linear_zoom_interpolation(&[
+                    (13.0, 0.0),
+                    (13.5, 1.0),
+                    (18.0, 11.0),
+                ])),
+                ..Default::default()
+            },
+        },
+        // roads_tunnels_major
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is(Brunnel::Tunnel),
+                ["in", schema.kind, "major_road", "primary", "secondary"]
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.structure))),
+                line_width: Some(linear_zoom_interpolation(&[
+                    (6.0, 0.0),
+                    (12.0, 1.6),
+                    (15.0, 3.0),
+                    (18.0, 13.0),
+                ])),
+                ..Default::default()
+            },
+        },
+        // roads_tunnels_highway
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is(Brunnel::Tunnel),
+                ["==", ["get", schema.kind], "highway"],
+                ["!", schema.is_link()]
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.structure))),
+                line_width: Some(linear_zoom_interpolation(&[
+                    (3.0, 0.0),
+                    (6.0, 1.65),
+                    (12.0, 2.4),
+                    (15.0, 7.5),
+                    (18.0, 22.5),
+                ])),
+                ..Default::default()
+            },
+        },
+        // buildings
+        Layer::Fill {
+            source_layer: schema.buildings.into(),
+            filter: Some(Filter(json!([
+                "in",
+                schema.kind,
+                "building",
+                "building_part"
+            ]))),
+            paint: Paint {
+                fill_color: Some(Color(json!(palette.structure))),
+                fill_opacity: Some(Float(json!(0.5))),
+                ..Default::default()
+            },
+        },
+        // roads_pier
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!(["==", schema.kind_detail, "pier"]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.pier))),
+                line_width: Some(linear_zoom_interpolation(&[
+                    (12.0, 0.0),
+                    (12.5, 0.5),
+                    (20.0, 16.0),
+                ])),
+                ..Default::default()
+            },
+        },
+        // roads_minor_service_casing
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is_not(Brunnel::Tunnel),
+                schema.is_not(Brunnel::Bridge),
+                ["in", schema.kind, "minor_road", "minor", "tertiary"],
+                ["==", schema.kind_detail, "service"]
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.casing))),
+                line_width: Some(linear_zoom_interpolation(&[(13.0, 0.0), (13.5, 0.8)])),
+                ..Default::default()
+            },
+        },
+        // roads_minor_casing
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is_not(Brunnel::Tunnel),
+                schema.is_not(Brunnel::Bridge),
+                ["in", schema.kind, "minor_road", "minor", "tertiary"],
+                ["!=", schema.kind_detail, "service"]
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.casing))),
+                line_width: Some(linear_zoom_interpolation(&[(12.0, 0.0), (12.5, 1.0)])),
+                ..Default::default()
+            },
+        },
+        // roads_link_casing
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!(schema.is_link()))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.casing))),
+                line_width: Some(linear_zoom_interpolation(&[(13.0, 0.0), (13.5, 1.5)])),
+                ..Default::default()
+            },
+        },
+        // roads_major_casing_late
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is_not(Brunnel::Tunnel),
+                schema.is_not(Brunnel::Bridge),
+                ["in", schema.kind, "major_road", "primary", "secondary"]
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.casing))),
+                line_width: Some(linear_zoom_interpolation(&[(9.0, 0.0), (9.5, 1.0)])),
+                ..Default::default()
+            },
+        },
+        // roads_highway_casing_late
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is_not(Brunnel::Tunnel),
+                schema.is_not(Brunnel::Bridge),
+                ["in", schema.kind, "highway", "motorway", "trunk"],
+                schema.is_not_link()
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.casing))),
+                line_width: Some(linear_zoom_interpolation(&[
+                    (7.0, 0.0),
+                    (7.5, 1.5),
+                    (20.0, 22.5),
+                ])),
+                ..Default::default()
+            },
+        },
+        // roads_other
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is_not(Brunnel::Tunnel),
+                schema.is_not(Brunnel::Bridge),
+                ["in", schema.kind, "other", "path", "service", "track"],
+                ["!=", schema.kind_detail, "pier"]
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.structure))),
+                line_width: Some(linear_zoom_interpolation(&[
+                    (11.0, 0.0),
+                    (12.0, 1.0),
+                    (20.0, 7.0),
+                ])),
+                ..Default::default()
+            },
+        },
+        // roads_link
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!(schema.is_link()))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.bridge))),
+                line_width: Some(linear_zoom_interpolation(&[
+                    (13.0, 0.0),
+                    (13.5, 1.0),
+                    (18.0, 11.0),
+                ])),
+                ..Default::default()
+            },
+        },
+        // roads_minor
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is_not(Brunnel::Tunnel),
+                schema.is_not(Brunnel::Bridge),
+                ["in", schema.kind, "minor_road", "minor", "tertiary"]
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.road))),
+                line_width: Some(linear_zoom_interpolation(&[
+                    (11.0, 0.0),
+                    (12.0, 1.0),
+                    (20.0, 7.0),
+                ])),
+                ..Default::default()
+            },
+        },
+        // roads_major_border
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is_not(Brunnel::Tunnel),
+                schema.is_not(Brunnel::Bridge),
+                ["in", schema.kind, "major_road", "primary", "secondary"]
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.major_road_border))),
+                line_width: Some(linear_zoom_interpolation(&[
+                    (6.0, 0.0),
+                    (12.0, 1.6),
+                    (15.0, 5.0),
+                    (18.0, 17.0),
+                ])),
+                ..Default::default()
+            },
+        },
+        // roads_major
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is_not(Brunnel::Tunnel),
+                schema.is_not(Brunnel::Bridge),
+                ["in", schema.kind, "major_road", "primary", "secondary"]
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.road))),
+                line_width: Some(linear_zoom_interpolation(&[
+                    (6.0, 0.0),
+                    (12.0, 1.6),
+                    (15.0, 3.0),
+                    (18.0, 13.0),
+                ])),
+                ..Default::default()
+            },
+        },
+        // roads_highway
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is_not(Brunnel::Tunnel),
+                schema.is_not(Brunnel::Bridge),
+                ["in", schema.kind, "highway", "motorway", "trunk"],
+                schema.is_not_link()
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.highway))),
+                line_width: Some(linear_zoom_interpolation(&[
+                    (3.0, 0.0),
+                    (6.0, 1.65),
+                    (12.0, 2.4),
+                    (15.0, 7.5),
+                    (18.0, 22.5),
+                ])),
+                ..Default::default()
+            },
+        },
+        // roads_rail
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!(["in", schema.kind, "rail", "transit"]))),
+            paint: Paint {
+                //line_opacity: Some(Float(json!(0.5))),
+                line_color: Some(Color(json!(palette.rail))),
+                line_width: Some(linear_zoom_interpolation(&[(3.0, 0.0), (18.0, 3.5)])),
+                ..Default::default()
+            },
+        },
+        // roads_rail_inside
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!(["in", schema.kind, "rail", "transit"]))),
+            paint: Paint {
+                line_opacity: Some(Float(json!(0.5))),
+                line_color: Some(Color(json!(palette.rail_tie))),
+                line_dasharray: Some(Dasharray(json!([4, 1]))),
+                line_width: Some(linear_zoom_interpolation(&[(3.0, 0.0), (18.0, 2.0)])),
+                ..Default::default()
+            },
+        },
+        // boundaries_country
+        Layer::Line {
+            source_layer: schema.boundaries.into(),
+            filter: Some(Filter(json!(["<=", schema.kind_detail, 2]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.label))),
+                line_width: Some(Float(json!(2))),
+                line_dasharray: Some(Dasharray(json!([
+                    "step",
+                    ["zoom"],
+                    ["literal", [2, 0]],
+                    4,
+                    ["literal", [2, 1]]
+                ]))),
+                ..Default::default()
+            },
+        },
+        // roads_bridges_other_casing
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is(Brunnel::Bridge),
+                ["in", schema.kind, "other", "path", "service", "track"]
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.casing))),
+                ..Default::default()
+            },
+        },
+        // roads_bridges_link_casing
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is(Brunnel::Bridge),
+                schema.is_link()
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.casing))),
+                line_width: Some(linear_zoom_interpolation(&[(12.0, 0.0), (12.5, 1.5)])),
+                ..Default::default()
+            },
+        },
+        // roads_bridges_minor_casing
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is(Brunnel::Bridge),
+                ["in", schema.kind, "minor_road", "minor", "tertiary"]
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.casing))),
+                line_width: Some(linear_zoom_interpolation(&[(13.0, 0.0), (13.5, 0.8)])),
+                ..Default::default()
+            },
+        },
+        // roads_bridges_major_casing
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is(Brunnel::Bridge),
+                ["in", schema.kind, "major_road", "primary", "secondary"]
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.casing))),
+                line_width: Some(linear_zoom_interpolation(&[(9.0, 0.0), (9.5, 1.5)])),
+                ..Default::default()
+            },
+        },
+        // roads_bridges_other
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is(Brunnel::Bridge),
+                ["in", schema.kind, "other", "path", "service", "track"]
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.bridge))),
+                line_dasharray: Some(Dasharray(json!([2, 1]))),
+                line_width: Some(linear_zoom_interpolation(&[(14.0, 0.0), (20.0, 7.0)])),
+                ..Default::default()
+            },
+        },
+        // roads_bridges_minor
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is(Brunnel::Bridge),
+                ["in", schema.kind, "minor_road", "minor", "tertiary"]
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.bridge))),
+                line_width: Some(linear_zoom_interpolation(&[
+                    (11.0, 0.0),
+                    (12.5, 0.5),
+                    (15.0, 2.0),
+                    (18.0, 11.0),
+                ])),
+                ..Default::default()
+            },
+        },
+        // roads_bridges_link
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is(Brunnel::Bridge),
+                schema.is_link()
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.bridge))),
+                line_width: Some(linear_zoom_interpolation(&[
+                    (13.0, 0.0),
+                    (13.5, 1.0),
+                    (18.0, 11.0),
+                ])),
+                ..Default::default()
+            },
+        },
+        // roads_bridges_major
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is(Brunnel::Bridge),
+                ["in", schema.kind, "major_road", "primary", "secondary"]
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.structure))),
+                line_width: Some(linear_zoom_interpolation(&[
+                    (6.0, 0.0),
+                    (12.0, 1.6),
+                    (15.0, 3.0),
+                    (18.0, 13.0),
+                ])),
+                ..Default::default()
+            },
+        },
+        // roads_bridges_highway_casing
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is(Brunnel::Bridge),
+                ["in", schema.kind, "highway", "motorway", "trunk"],
+                schema.is_not_link()
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.casing))),
+                line_width: Some(linear_zoom_interpolation(&[
+                    (7.0, 0.0),
+                    (7.5, 1.5),
+                    (20.0, 22.5),
+                ])),
+                ..Default::default()
+            },
+        },
+        // roads_bridges_highway
+        Layer::Line {
+            source_layer: schema.roads.into(),
+            filter: Some(Filter(json!([
+                "all",
+                schema.is(Brunnel::Bridge),
+                ["in", schema.kind, "highway", "motorway", "trunk"],
+                schema.is_not_link()
+            ]))),
+            paint: Paint {
+                line_color: Some(Color(json!(palette.structure))),
+                line_width: Some(linear_zoom_interpolation(&[
+                    (3.0, 0.0),
+                    (6.0, 1.65),
+                    (12.0, 2.4),
+                    (15.0, 7.5),
+                    (18.0, 22.5),
+                ])),
+                ..Default::default()
+            },
+        },
+        // address_label
+        Layer::Symbol {
+            source_layer: schema.buildings.into(),
+            filter: Some(Filter(json!(["==", schema.kind, "address"]))),
+            layout: Layout {
+                text_field: Some(json!(["get", "addr_housenumber"])),
+                text_size: Some(Float(json!(10))),
+            },
+            paint: Some(Paint {
+                text_color: Some(Color(json!(palette.label))),
+                text_halo_color: Some(Color(json!(palette.casing))),
+                ..Default::default()
+            }),
+        },
+        // water_waterway_label
+        Layer::Symbol {
+            source_layer: schema.waterway.into(),
+            filter: Some(Filter(json!(["in", schema.kind, "river", "stream"]))),
+            layout: Layout {
+                text_field: Some(json!(["get", "name"])),
+                text_size: Some(Float(json!(12))),
+            },
+            paint: Some(Paint {
+                text_color: Some(Color(json!(palette.label))),
+                text_halo_color: Some(Color(json!(palette.muted))),
+                ..Default::default()
+            }),
+        },
+        // roads_oneway
+        Layer::Symbol {
+            source_layer: schema.road_labels.into(),
+            filter: Some(Filter(json!(["==", ["get", "oneway"], "yes"]))),
+            layout: Layout {
+                text_field: None,
+                text_size: None,
+            },
+            paint: None,
+        },
+        // roads_labels_minor
+        Layer::Symbol {
+            source_layer: schema.road_labels.into(),
+            filter: Some(Filter(json!([
+                "in",
+                schema.kind,
+                "minor_road",
+                "other",
+                "path"
+            ]))),
+            layout: Layout {
+                text_field: Some(json!(["get", "name"])),
+                text_size: Some(Float(json!(12))),
+            },
+            paint: Some(Paint {
+                text_color: Some(Color(json!(palette.label_muted))),
+                text_halo_color: Some(Color(json!(palette.background))),
+                ..Default::default()
+            }),
+        },
+        // water_label_ocean
+        Layer::Symbol {
+            source_layer: schema.water.into(),
+            filter: Some(Filter(json!([
+                "in",
+                schema.kind,
+                "sea",
+                "ocean",
+                "bay",
+                "strait",
+                "fjord"
+            ]))),
+            layout: Layout {
+                text_field: Some(json!(["get", "name"])),
+                text_size: Some(linear_zoom_interpolation(&[(3.0, 10.0), (10.0, 12.0)])),
+            },
+            paint: Some(Paint {
+                text_color: Some(Color(json!(palette.label))),
+                text_halo_color: Some(Color(json!(palette.muted))),
+                ..Default::default()
+            }),
+        },
+        // earth_label_islands
+        Layer::Symbol {
+            source_layer: schema.earth.into(),
+            filter: Some(Filter(json!(["in", schema.kind, "island"]))),
+            layout: Layout {
+                text_field: Some(json!(["get", "name"])),
+                text_size: Some(Float(json!(10))),
+            },
+            paint: Some(Paint {
+                text_color: Some(Color(json!(palette.label_muted))),
+                text_halo_color: Some(Color(json!(palette.casing))),
+                ..Default::default()
+            }),
+        },
+        // water_label_lakes
+        Layer::Symbol {
+            source_layer: schema.water.into(),
+            filter: Some(Filter(json!(["in", schema.kind, "lake", "water"]))),
+            layout: Layout {
+                text_field: Some(json!(["get", "name"])),
+                text_size: Some(linear_zoom_interpolation(&[
+                    (3.0, 10.0),
+                    (6.0, 12.0),
+                    (10.0, 12.0),
+                ])),
+            },
+            paint: Some(Paint {
+                text_color: Some(Color(json!(palette.label))),
+                text_halo_color: Some(Color(json!(palette.muted))),
+                ..Default::default()
+            }),
+        },
+        // roads_shields
+        Layer::Symbol {
+            source_layer: schema.road_labels.into(),
+            filter: Some(Filter(json!([
+                "all",
+                [
+                    "in",
+                    ["get", schema.kind],
+                    ["literal", ["highway", "major_road"]]
+                ],
+                ["has", "shield_text"],
+                ["<=", ["length", ["get", "shield_text"]], 5]
+            ]))),
+            layout: Layout {
+                text_field: Some(json!(["get", "shield_text"])),
+                text_size: Some(Float(json!(8))),
+            },
+            paint: Some(Paint {
+                text_color: Some(Color(json!(palette.label_muted))),
+                ..Default::default()
+            }),
+        },
+        // roads_labels_major
+        Layer::Symbol {
+            source_layer: schema.road_labels.into(),
+            filter: Some(Filter(json!(["in", schema.kind, "highway", "major_road"]))),
+            layout: Layout {
+                text_field: Some(json!(["get", "name"])),
+                text_size: Some(Float(json!(13))),
+            },
+            paint: Some(Paint {
+                text_color: Some(Color(json!(palette.label))),
+                text_halo_color: Some(Color(json!(palette.background))),
+                ..Default::default()
+            }),
+        },
+        // places_subplace
+        Layer::Symbol {
+            source_layer: schema.places.into(),
+            filter: Some(Filter(json!([
+                "in",
+                schema.kind,
+                "neighbourhood",
+                "macrohood"
+            ]))),
+            layout: Layout {
+                text_field: Some(json!(["get", "name"])),
+                text_size: Some(linear_zoom_interpolation(&[
+                    (11.0, 8.0),
+                    (14.0, 14.0),
+                    (18.0, 24.0),
+                ])),
+            },
+            paint: Some(Paint {
+                text_color: Some(Color(json!(palette.label_muted))),
+                text_halo_color: Some(Color(json!(palette.casing))),
+                ..Default::default()
+            }),
+        },
+        // places_region
+        Layer::Symbol {
+            source_layer: schema.places.into(),
+            filter: Some(Filter(json!(["==", schema.kind, "region"]))),
+            layout: Layout {
+                text_field: Some(json!(["get", "name"])),
+                text_size: Some(linear_zoom_interpolation(&[(3.0, 11.0), (7.0, 16.0)])),
+            },
+            paint: Some(Paint {
+                text_color: Some(Color(json!(palette.label))),
+                text_halo_color: Some(Color(json!(palette.casing))),
+                ..Default::default()
+            }),
+        },
+        // places_locality
+        Layer::Symbol {
+            source_layer: schema.places.into(),
+            filter: Some(Filter(json!(["==", schema.kind, "locality"]))),
+            layout: Layout {
+                text_field: Some(json!(["get", "name"])),
+                text_size: Some(Float(json!([
+                    "interpolate",
+                    ["linear"],
+                    ["zoom"],
+                    2,
+                    [
+                        "case",
+                        ["<", ["get", schema.place_rank], 13],
+                        8,
+                        [">=", ["get", schema.place_rank], 13],
+                        13,
+                        0
+                    ],
+                    4,
+                    [
+                        "case",
+                        ["<", ["get", schema.place_rank], 13],
+                        10,
+                        [">=", ["get", schema.place_rank], 13],
+                        15,
+                        0
+                    ],
+                    6,
+                    [
+                        "case",
+                        ["<", ["get", schema.place_rank], 12],
+                        11,
+                        [">=", ["get", schema.place_rank], 12],
+                        17,
+                        0
+                    ],
+                    8,
+                    [
+                        "case",
+                        ["<", ["get", schema.place_rank], 11],
+                        11,
+                        [">=", ["get", schema.place_rank], 11],
+                        18,
+                        0
+                    ],
+                    10,
+                    [
+                        "case",
+                        ["<", ["get", schema.place_rank], 9],
+                        12,
+                        [">=", ["get", schema.place_rank], 9],
+                        20,
+                        0
+                    ],
+                    15,
+                    [
+                        "case",
+                        ["<", ["get", schema.place_rank], 8],
+                        12,
+                        [">=", ["get", schema.place_rank], 8],
+                        22,
+                        0
+                    ]
+                ]))),
+            },
+            paint: Some(Paint {
+                text_color: Some(Color(json!(palette.locality_text))),
+                text_halo_color: Some(Color(json!(palette.casing))),
+                ..Default::default()
+            }),
+        },
+        // places_country
+        Layer::Symbol {
+            source_layer: schema.places.into(),
+            filter: Some(Filter(json!(["==", schema.kind, "country"]))),
+            layout: Layout {
+                text_field: Some(json!(["get", "name:en"])),
+                text_size: Some(Float(json!([
+                    "interpolate",
+                    ["linear"],
+                    ["zoom"],
+                    2,
+                    [
+                        "case",
+                        ["<", ["get", schema.place_rank], 10],
+                        8,
+                        [">=", ["get", schema.place_rank], 10],
+                        12,
+                        0
+                    ],
+                    6,
+                    [
+                        "case",
+                        ["<", ["get", schema.place_rank], 8],
+                        10,
+                        [">=", ["get", schema.place_rank], 8],
+                        18,
+                        0
+                    ],
+                    8,
+                    [
+                        "case",
+                        ["<", ["get", schema.place_rank], 7],
+                        11,
+                        [">=", ["get", schema.place_rank], 7],
+                        20,
+                        0
+                    ]
+                ]))),
+            },
+            paint: Some(Paint {
+                text_color: Some(Color(json!(palette.label))),
+                text_halo_color: Some(Color(json!(palette.casing))),
+                ..Default::default()
+            }),
+        },
+        // stations
+        Layer::Symbol {
+            source_layer: schema.pois.into(),
+            filter: Some(Filter(json!(["==", schema.kind, "station"]))),
+            layout: Layout {
+                text_field: Some(json!(["get", "name"])),
+                text_size: Some(Float(json!(11))),
+            },
+            paint: Some(Paint {
+                text_color: Some(Color(json!(palette.station))),
+                text_halo_color: Some(Color(json!(palette.casing))),
+                ..Default::default()
+            }),
+        },
+    ];
+
+    // A schema which does not carry a layer leaves its name empty, and an empty source layer
+    // would match every layer of the tile rather than none.
+    layers.retain(|layer| match layer {
+        Layer::Fill { source_layer, .. }
+        | Layer::Line { source_layer, .. }
+        | Layer::Symbol { source_layer, .. } => !source_layer.is_empty(),
+        _ => true,
+    });
+
+    Style { layers }
+}
+
+/// Which of the two palettes a style is built from.
+#[derive(Clone, Copy, PartialEq)]
+pub enum Shade {
+    Light,
+    Dark,
+}
+
+impl Shade {
+    /// In the order they are offered.
+    pub const ALL: [Shade; 2] = [Shade::Light, Shade::Dark];
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Shade::Light => "light",
+            Shade::Dark => "dark",
+        }
+    }
+}
+
+pub fn style(shade: Shade, schema: Schema) -> Style {
+    build(
+        match shade {
+            Shade::Light => &LIGHT,
+            Shade::Dark => &DARK,
+        },
+        schema,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn source_layers(style: &Style) -> HashSet<String> {
+        style
+            .layers
+            .iter()
+            .filter_map(|layer| match layer {
+                Layer::Fill { source_layer, .. }
+                | Layer::Line { source_layer, .. }
+                | Layer::Symbol { source_layer, .. } => Some(source_layer.to_owned()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// OpenMapTiles has no land polygon, so it ends up with fewer layers than Protomaps.
+    #[test]
+    fn a_schema_only_gets_the_layers_it_can_serve() {
+        assert!(
+            style(Shade::Light, PROTOMAPS).layers.len()
+                > style(Shade::Light, OPENMAPTILES).layers.len()
+        );
+        assert_eq!(
+            style(Shade::Dark, PROTOMAPS).layers.len(),
+            style(Shade::Light, PROTOMAPS).layers.len()
+        );
+        assert!(source_layers(&style(Shade::Light, PROTOMAPS)).contains("earth"));
+        assert!(!source_layers(&style(Shade::Light, OPENMAPTILES)).contains("earth"));
+    }
+
+    #[test]
+    fn each_schema_asks_for_its_own_source_layers() {
+        let protomaps = source_layers(&style(Shade::Light, PROTOMAPS));
+        let openmaptiles = source_layers(&style(Shade::Light, OPENMAPTILES));
+
+        assert!(protomaps.contains("roads"));
+        assert!(protomaps.contains("buildings"));
+        assert!(!protomaps.contains("transportation"));
+
+        assert!(openmaptiles.contains("transportation"));
+        assert!(openmaptiles.contains("transportation_name"));
+        assert!(openmaptiles.contains("waterway"));
+        assert!(openmaptiles.contains("building"));
+        assert!(!openmaptiles.contains("roads"));
+    }
+
+    /// An empty source layer scans every layer of a tile, which is ruinous for a basemap.
+    #[test]
+    fn no_layer_matches_everything() {
+        for style in [
+            style(Shade::Light, PROTOMAPS),
+            style(Shade::Light, OPENMAPTILES),
+        ] {
+            assert!(!source_layers(&style).contains(""));
+        }
+    }
+}

--- a/wanderers/src/map_style.rs
+++ b/wanderers/src/map_style.rs
@@ -4,17 +4,11 @@ use walkers::{
 
 /// Which vector tile schema the tiles follow.
 ///
-/// Protomaps and OpenMapTiles carry the same world under different names, and the names are
-/// the only thing a filter cannot reach: `source_layer` picks the tile layer before there is
-/// any feature to test. Everything else - property keys, value vocabularies - is handled in
-/// the filters themselves.
+/// Only the names live here. Differing property values are absorbed by the filters, which is
+/// not possible for layer names because `source_layer` is read before there is any feature.
 #[derive(Clone, Copy)]
 pub struct Schema {
     earth: &'static str,
-
-    /// Protomaps keeps parks, forests and hospitals together; OpenMapTiles spreads them over
-    /// three layers. The filters already accept both vocabularies, so naming all three is
-    /// enough - no layer has to be repeated.
     landuse: &'static [&'static str],
     water: &'static str,
     waterway: &'static str,
@@ -31,7 +25,6 @@ pub struct Schema {
     link: &'static str,
 }
 
-/// Served by Protomaps `.pmtiles`.
 pub const PROTOMAPS: Schema = Schema {
     earth: "earth",
     landuse: &["landuse"],
@@ -50,8 +43,7 @@ pub const PROTOMAPS: Schema = Schema {
     link: "is_link",
 };
 
-/// Served by OpenFreeMap. There is no land polygon here - the background stands in for one -
-/// so `earth` is empty and the layers asking for it are dropped.
+/// `earth` is empty because there is no land polygon here; the background stands in for it.
 pub const OPENMAPTILES: Schema = Schema {
     earth: "",
     landuse: &["landcover", "landuse", "park"],
@@ -78,7 +70,6 @@ pub enum Brunnel {
 }
 
 impl Brunnel {
-    /// Protomaps flags it with a property of its own, OpenMapTiles with a value.
     fn protomaps(self) -> &'static str {
         match self {
             Brunnel::Tunnel => "is_tunnel",
@@ -1330,7 +1321,6 @@ fn source_layer_of(layer: &Layer) -> Option<&SourceLayer> {
     }
 }
 
-/// Which of the two palettes a style is built from.
 #[derive(Clone, Copy, PartialEq)]
 pub enum Shade {
     Light,
@@ -1363,7 +1353,6 @@ pub fn style(shade: Shade, schema: Schema) -> Style {
 mod tests {
     use super::*;
 
-    /// Whether any layer of the style draws from a tile layer of this name.
     fn asks_for(style: &Style, name: &str) -> bool {
         style
             .layers
@@ -1379,7 +1368,6 @@ mod tests {
         assert!(!asks_for(&style(Shade::Light, OPENMAPTILES), "earth"));
     }
 
-    /// The palette changes the colours, never which layers there are.
     #[test]
     fn both_shades_draw_the_same_layers() {
         for schema in [PROTOMAPS, OPENMAPTILES] {
@@ -1390,8 +1378,7 @@ mod tests {
         }
     }
 
-    /// OpenMapTiles spreads landuse over three tile layers. One style layer names all three,
-    /// rather than being repeated once per name.
+    /// OpenMapTiles spreads landuse over `landcover`, `landuse` and `park`.
     #[test]
     fn a_concept_split_across_layers_needs_no_extra_layers() {
         let openmaptiles = style(Shade::Light, OPENMAPTILES);

--- a/wanderers/src/map_style.rs
+++ b/wanderers/src/map_style.rs
@@ -1,4 +1,6 @@
-use walkers::{Color, Dasharray, Filter, Float, Layer, Layout, Paint, Style, Value, json};
+use walkers::{
+    Color, Dasharray, Filter, Float, Layer, Layout, Paint, SourceLayer, Style, Value, json,
+};
 
 /// Which vector tile schema the tiles follow.
 ///
@@ -9,7 +11,11 @@ use walkers::{Color, Dasharray, Filter, Float, Layer, Layout, Paint, Style, Valu
 #[derive(Clone, Copy)]
 pub struct Schema {
     earth: &'static str,
-    landuse: &'static str,
+
+    /// Protomaps keeps parks, forests and hospitals together; OpenMapTiles spreads them over
+    /// three layers. The filters already accept both vocabularies, so naming all three is
+    /// enough - no layer has to be repeated.
+    landuse: &'static [&'static str],
     water: &'static str,
     waterway: &'static str,
     roads: &'static str,
@@ -28,7 +34,7 @@ pub struct Schema {
 /// Served by Protomaps `.pmtiles`.
 pub const PROTOMAPS: Schema = Schema {
     earth: "earth",
-    landuse: "landuse",
+    landuse: &["landuse"],
     water: "water",
     waterway: "water",
     roads: "roads",
@@ -48,7 +54,7 @@ pub const PROTOMAPS: Schema = Schema {
 /// so `earth` is empty and the layers asking for it are dropped.
 pub const OPENMAPTILES: Schema = Schema {
     earth: "",
-    landuse: "landcover",
+    landuse: &["landcover", "landuse", "park"],
     water: "water",
     waterway: "waterway",
     roads: "transportation",
@@ -1310,14 +1316,18 @@ fn build(palette: &Palette, schema: Schema) -> Style {
 
     // A schema which does not carry a layer leaves its name empty, and an empty source layer
     // would match every layer of the tile rather than none.
-    layers.retain(|layer| match layer {
-        Layer::Fill { source_layer, .. }
-        | Layer::Line { source_layer, .. }
-        | Layer::Symbol { source_layer, .. } => !source_layer.is_empty(),
-        _ => true,
-    });
+    layers.retain(|layer| source_layer_of(layer).is_none_or(|source| !source.is_all()));
 
     Style { layers }
+}
+
+fn source_layer_of(layer: &Layer) -> Option<&SourceLayer> {
+    match layer {
+        Layer::Fill { source_layer, .. }
+        | Layer::Line { source_layer, .. }
+        | Layer::Symbol { source_layer, .. } => Some(source_layer),
+        _ => None,
+    }
 }
 
 /// Which of the two palettes a style is built from.
@@ -1352,60 +1362,87 @@ pub fn style(shade: Shade, schema: Schema) -> Style {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashSet;
 
-    fn source_layers(style: &Style) -> HashSet<String> {
+    /// Whether any layer of the style draws from a tile layer of this name.
+    fn asks_for(style: &Style, name: &str) -> bool {
         style
             .layers
             .iter()
-            .filter_map(|layer| match layer {
-                Layer::Fill { source_layer, .. }
-                | Layer::Line { source_layer, .. }
-                | Layer::Symbol { source_layer, .. } => Some(source_layer.to_owned()),
-                _ => None,
-            })
-            .collect()
+            .filter_map(source_layer_of)
+            .any(|source| source.matches(name))
     }
 
-    /// OpenMapTiles has no land polygon, so it ends up with fewer layers than Protomaps.
+    /// OpenMapTiles has no land polygon, so those layers are dropped rather than asked for.
     #[test]
     fn a_schema_only_gets_the_layers_it_can_serve() {
-        assert!(
-            style(Shade::Light, PROTOMAPS).layers.len()
-                > style(Shade::Light, OPENMAPTILES).layers.len()
-        );
+        assert!(asks_for(&style(Shade::Light, PROTOMAPS), "earth"));
+        assert!(!asks_for(&style(Shade::Light, OPENMAPTILES), "earth"));
+    }
+
+    /// The palette changes the colours, never which layers there are.
+    #[test]
+    fn both_shades_draw_the_same_layers() {
+        for schema in [PROTOMAPS, OPENMAPTILES] {
+            assert_eq!(
+                style(Shade::Dark, schema).layers.len(),
+                style(Shade::Light, schema).layers.len()
+            );
+        }
+    }
+
+    /// OpenMapTiles spreads landuse over three tile layers. One style layer names all three,
+    /// rather than being repeated once per name.
+    #[test]
+    fn a_concept_split_across_layers_needs_no_extra_layers() {
+        let openmaptiles = style(Shade::Light, OPENMAPTILES);
+
+        for name in ["landcover", "landuse", "park"] {
+            assert!(asks_for(&openmaptiles, name), "does not ask for {name}");
+        }
+
+        let landuse_layers = |style: &Style| {
+            style
+                .layers
+                .iter()
+                .filter_map(source_layer_of)
+                .filter(|source| source.matches("landcover") || source.matches("landuse"))
+                .count()
+        };
+
         assert_eq!(
-            style(Shade::Dark, PROTOMAPS).layers.len(),
-            style(Shade::Light, PROTOMAPS).layers.len()
+            landuse_layers(&openmaptiles),
+            landuse_layers(&style(Shade::Light, PROTOMAPS))
         );
-        assert!(source_layers(&style(Shade::Light, PROTOMAPS)).contains("earth"));
-        assert!(!source_layers(&style(Shade::Light, OPENMAPTILES)).contains("earth"));
     }
 
     #[test]
     fn each_schema_asks_for_its_own_source_layers() {
-        let protomaps = source_layers(&style(Shade::Light, PROTOMAPS));
-        let openmaptiles = source_layers(&style(Shade::Light, OPENMAPTILES));
+        let protomaps = style(Shade::Light, PROTOMAPS);
+        let openmaptiles = style(Shade::Light, OPENMAPTILES);
 
-        assert!(protomaps.contains("roads"));
-        assert!(protomaps.contains("buildings"));
-        assert!(!protomaps.contains("transportation"));
+        assert!(asks_for(&protomaps, "roads"));
+        assert!(asks_for(&protomaps, "buildings"));
+        assert!(!asks_for(&protomaps, "transportation"));
 
-        assert!(openmaptiles.contains("transportation"));
-        assert!(openmaptiles.contains("transportation_name"));
-        assert!(openmaptiles.contains("waterway"));
-        assert!(openmaptiles.contains("building"));
-        assert!(!openmaptiles.contains("roads"));
+        assert!(asks_for(&openmaptiles, "transportation"));
+        assert!(asks_for(&openmaptiles, "transportation_name"));
+        assert!(asks_for(&openmaptiles, "waterway"));
+        assert!(asks_for(&openmaptiles, "building"));
+        assert!(!asks_for(&openmaptiles, "roads"));
     }
 
-    /// An empty source layer scans every layer of a tile, which is ruinous for a basemap.
+    /// A layer matching everything scans every layer of a tile, ruinous for a basemap.
     #[test]
     fn no_layer_matches_everything() {
-        for style in [
-            style(Shade::Light, PROTOMAPS),
-            style(Shade::Light, OPENMAPTILES),
-        ] {
-            assert!(!source_layers(&style).contains(""));
+        for schema in [PROTOMAPS, OPENMAPTILES] {
+            let style = style(Shade::Light, schema);
+            assert!(
+                style
+                    .layers
+                    .iter()
+                    .filter_map(source_layer_of)
+                    .all(|source| !source.is_all())
+            );
         }
     }
 }


### PR DESCRIPTION
Taken from widnet and parameterised by tile schema, so one set of layers serves both Protomaps and OpenMapTiles. Property keys, value vocabularies and the tunnel/bridge/ramp encodings are absorbed by the filters.

Source layer names could not be, so `source_layer` now takes a list as well as a name — an empty one already meant "every layer of the tile", so it becomes a type which says so. Both forms deserialize, leaving existing styles alone. That removes code rather than adding it: the two paths through `get_layer_features` become one, and `find_layer` goes away with the two error variants only it raised.

Offered in light and dark as separate entries, and `.pmtiles` files found next to the app show up as basemaps of their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
