### PR TITLE
Draw lines the width the style asked for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 * Fix `fill` layers not rendering features made of a single polygon.
 * `source_layer` is now a `SourceLayer`, which can name several layers of a vector tile instead
   of one. It still takes a plain name, and an empty one still matches all of them.
+* `line-width` is now in screen pixels, so lines are thicker than before.
 
 ## 0.58.0
 

--- a/walkers/src/render.rs
+++ b/walkers/src/render.rs
@@ -49,16 +49,47 @@ impl From<Mesh> for ShapeOrText {
 }
 
 impl ShapeOrText {
+    /// Move a shape from the space it was rendered in onto the screen.
+    ///
+    /// Geometry scales, stroke widths do not: a `line-width` of 4 means four pixels on the
+    /// screen at any zoom, the way the style spec means it, rather than four pixels only at
+    /// whichever zoom the tile happened to be rendered for. Text has always worked this way,
+    /// since its font size is not scaled either.
     pub fn transform(&mut self, transform: TSTransform) {
         match self {
             ShapeOrText::Shape(shape) => {
                 shape.transform(transform);
+                keep_stroke_width(shape, transform.scaling);
             }
             ShapeOrText::Text(Text { position, .. }) => {
                 *position *= transform.scaling;
                 *position += transform.translation;
             }
         }
+    }
+}
+
+/// Undo what [`Shape::transform`] did to the stroke widths, which it scales along with
+/// everything else.
+fn keep_stroke_width(shape: &mut Shape, scaling: f32) {
+    if scaling == 0.0 {
+        return;
+    }
+
+    match shape {
+        Shape::Vec(shapes) => {
+            for shape in shapes {
+                keep_stroke_width(shape, scaling);
+            }
+        }
+        Shape::Path(path) => path.stroke.width /= scaling,
+        Shape::LineSegment { stroke, .. } => stroke.width /= scaling,
+        Shape::Circle(circle) => circle.stroke.width /= scaling,
+        Shape::Ellipse(ellipse) => ellipse.stroke.width /= scaling,
+        Shape::Rect(rect) => rect.stroke.width /= scaling,
+        Shape::QuadraticBezier(curve) => curve.stroke.width /= scaling,
+        Shape::CubicBezier(curve) => curve.stroke.width /= scaling,
+        Shape::Noop | Shape::Text(_) | Shape::Mesh(_) | Shape::Callback(_) => {}
     }
 }
 
@@ -95,10 +126,9 @@ pub fn render_line(
     paint: &Paint,
 ) -> Result<(), Error> {
     let width = if let Some(width) = &paint.line_width {
-        // Align to the proportion of MVT extent and tile size.
-        width.evaluate(context) * 4.0
+        width.evaluate(context)
     } else {
-        2.0
+        1.0
     };
 
     let opacity = if let Some(opacity) = &paint.line_opacity {
@@ -593,5 +623,84 @@ mod tests {
             .len(),
             2
         );
+    }
+}
+
+#[cfg(test)]
+mod width_tests {
+    use super::*;
+    use crate::style::{Color, Float, Paint, json};
+
+    fn line_width_after(scaling: f32, asked: f32) -> f32 {
+        let context = Context::new("LineString".to_string(), Default::default(), 10);
+        let paint = Paint {
+            line_color: Some(Color(json!("#000000"))),
+            line_width: Some(Float(json!(asked))),
+            ..Default::default()
+        };
+        let geometry = Geometry::LineString(geo_types::LineString::from(vec![
+            (0.0f32, 0.0f32),
+            (100.0, 100.0),
+        ]));
+
+        let mut shapes = Vec::new();
+        render_line(&geometry, &context, &mut shapes, &paint).unwrap();
+
+        for shape in shapes.iter_mut() {
+            shape.transform(TSTransform {
+                scaling,
+                translation: Default::default(),
+            });
+        }
+
+        shapes
+            .iter()
+            .find_map(|shape| match shape {
+                ShapeOrText::Shape(Shape::LineSegment { stroke, .. }) => Some(stroke.width),
+                ShapeOrText::Shape(Shape::Path(path)) => Some(path.stroke.width),
+                _ => None,
+            })
+            .expect("no line")
+    }
+
+    /// A tile is drawn at whatever size the current zoom calls for, but `line-width` is in
+    /// screen pixels and must not follow it.
+    #[test]
+    fn line_width_survives_the_transform() {
+        for scaling in [256.0 / 4096.0, 362.0 / 4096.0, 511.0 / 4096.0, 1.0] {
+            let width = line_width_after(scaling, 4.0);
+            assert!(
+                (width - 4.0).abs() < 0.001,
+                "asked for 4.0, got {width} at scaling {scaling}"
+            );
+        }
+    }
+
+    #[test]
+    fn geometry_still_scales() {
+        let context = Context::new("LineString".to_string(), Default::default(), 10);
+        let geometry = Geometry::LineString(geo_types::LineString::from(vec![
+            (0.0f32, 0.0f32),
+            (4096.0, 0.0),
+        ]));
+
+        let mut shapes = Vec::new();
+        render_line(&geometry, &context, &mut shapes, &Paint::default()).unwrap();
+        for shape in shapes.iter_mut() {
+            shape.transform(TSTransform {
+                scaling: 256.0 / 4096.0,
+                translation: Default::default(),
+            });
+        }
+
+        let points = match &shapes[0] {
+            ShapeOrText::Shape(Shape::LineSegment { points, .. }) => points.to_vec(),
+            ShapeOrText::Shape(Shape::Path(path)) => path.points.to_vec(),
+            other => panic!("expected a line, got {other:?}"),
+        };
+
+        // The full extent of the tile lands on the full width it is drawn at.
+        assert_eq!(points[0].x, 0.0);
+        assert_eq!(points[points.len() - 1].x, 256.0);
     }
 }

--- a/wanderers/src/map_style.rs
+++ b/wanderers/src/map_style.rs
@@ -17,6 +17,7 @@ pub struct Schema {
     buildings: &'static str,
     places: &'static str,
     pois: &'static str,
+    peaks: &'static [&'static str],
     boundaries: &'static str,
     kind: &'static str,
     kind_detail: &'static str,
@@ -35,6 +36,7 @@ pub const PROTOMAPS: Schema = Schema {
     buildings: "buildings",
     places: "places",
     pois: "pois",
+    peaks: &["pois"],
     boundaries: "boundaries",
     kind: "kind",
     kind_detail: "kind_detail",
@@ -54,6 +56,7 @@ pub const OPENMAPTILES: Schema = Schema {
     buildings: "building",
     places: "place",
     pois: "poi",
+    peaks: &["mountain_peak"],
     boundaries: "boundary",
     kind: "class",
     kind_detail: "subclass",
@@ -145,6 +148,7 @@ struct Palette {
     locality_text: &'static str,
     water: &'static str,
     station: &'static str,
+    peak: &'static str,
 }
 
 const DARK: Palette = Palette {
@@ -168,6 +172,7 @@ const DARK: Palette = Palette {
     locality_text: "#999999",
     water: "#161e31",
     station: "#7fb3d9",
+    peak: "#b59a6a",
 };
 
 const LIGHT: Palette = Palette {
@@ -192,6 +197,7 @@ const LIGHT: Palette = Palette {
     locality_text: "#1a1a1a",
     water: "#88b2e2",
     station: "#2b6ca3",
+    peak: "#6b5330",
 };
 
 fn build(palette: &Palette, schema: Schema) -> Style {
@@ -1299,6 +1305,20 @@ fn build(palette: &Palette, schema: Schema) -> Style {
             },
             paint: Some(Paint {
                 text_color: Some(Color(json!(palette.station))),
+                text_halo_color: Some(Color(json!(palette.casing))),
+                ..Default::default()
+            }),
+        },
+        // peaks
+        Layer::Symbol {
+            source_layer: schema.peaks.into(),
+            filter: Some(Filter(json!(["in", schema.kind, "peak", "volcano"]))),
+            layout: Layout {
+                text_field: Some(json!(["get", "name"])),
+                text_size: Some(linear_zoom_interpolation(&[(8.0, 10.0), (14.0, 14.0)])),
+            },
+            paint: Some(Paint {
+                text_color: Some(Color(json!(palette.peak))),
                 text_halo_color: Some(Color(json!(palette.casing))),
                 ..Default::default()
             }),


### PR DESCRIPTION
`line-width` was multiplied by a constant and then scaled along with the tile, leaving it four times too thin at matching zoom and doubling it as one zoomed between levels before it snapped back. Geometry still scales; only the stroke widths are held, the way text already worked.

Styles tuned against the old rendering will draw thicker. Ones ported from real MapLibre styles should look right for the first time.

Also labels peaks in wanderers — `mountain_peak` under OpenMapTiles, the POIs under Protomaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
