### PR TITLE
Keep shapes and text apart

### DIFF
--- a/walkers/src/lib.rs
+++ b/walkers/src/lib.rs
@@ -53,6 +53,8 @@ pub use projector::Projector;
 pub use style::Style;
 #[cfg(feature = "mvt")]
 pub use style::{Color, Dasharray, Filter, Float, Layer, Layout, Paint, SourceLayer, Value, json};
+#[cfg(feature = "mvt")]
+pub use text::{Text, place_texts};
 pub use tiles::{Tile, TileId, TilePiece, Tiles};
 pub use zoom::InvalidZoom;
 
@@ -60,6 +62,4 @@ pub use zoom::InvalidZoom;
 #[cfg(feature = "mvt")]
 pub use expression::Context;
 #[cfg(feature = "mvt")]
-pub use render::{
-    Geometry, ShapeOrText, render_line, render_symbol, resolve_text, tessellate_polygon,
-};
+pub use render::{Geometry, render_line, render_symbol, tessellate_polygon};

--- a/walkers/src/mvt.rs
+++ b/walkers/src/mvt.rs
@@ -9,8 +9,9 @@ use serde_json::{Number, Value as JsonValue};
 
 use crate::{
     expression::Context,
-    render::{self, Geometry, ShapeOrText},
+    render::{self, Geometry},
     style::{Filter, Layer, SourceLayer, Style},
+    text::Text,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -30,9 +31,10 @@ impl From<mvt_reader::error::ParserError> for Error {
 const ONLY_SUPPORTED_EXTENT: u32 = 4096;
 
 /// Render MVT data into a list of [`epaint::Shape`]s.
-pub fn render(data: &[u8], style: &Style, zoom: u8) -> Result<Vec<ShapeOrText>, Error> {
+pub fn render(data: &[u8], style: &Style, zoom: u8) -> Result<(Vec<Shape>, Vec<Text>), Error> {
     let data = mvt_reader::Reader::new(data.to_vec())?;
     let mut shapes = Vec::new();
+    let mut texts = Vec::new();
 
     for layer in &style.layers {
         match layer {
@@ -49,7 +51,7 @@ pub fn render(data: &[u8], style: &Style, zoom: u8) -> Result<Vec<ShapeOrText>, 
                     pos2(0.0, 0.0),
                     vec2(ONLY_SUPPORTED_EXTENT as f32, ONLY_SUPPORTED_EXTENT as f32),
                 );
-                shapes.push(Shape::rect_filled(rect, 0.0, bg_color).into());
+                shapes.push(Shape::rect_filled(rect, 0.0, bg_color));
             }
             Layer::Fill {
                 source_layer,
@@ -89,7 +91,7 @@ pub fn render(data: &[u8], style: &Style, zoom: u8) -> Result<Vec<ShapeOrText>, 
                     get_layer_features(&data, zoom, source_layer, filter.as_ref())?
                 {
                     if let Err(err) =
-                        render::render_symbol(&geometry, &context, &mut shapes, layout, paint)
+                        render::render_symbol(&geometry, &context, &mut texts, layout, paint)
                     {
                         warn!("{err}");
                     }
@@ -103,21 +105,15 @@ pub fn render(data: &[u8], style: &Style, zoom: u8) -> Result<Vec<ShapeOrText>, 
     }
 
     log::trace!("Rendered {} shapes", shapes.len());
-    Ok(shapes)
+    Ok((shapes, texts))
 }
 
-/// Transform shapes from MVT space to screen space.
-pub fn transformed(shapes: &[ShapeOrText], rect: egui::Rect) -> Vec<ShapeOrText> {
-    let transform = TSTransform {
+/// What takes a tile from MVT space onto the screen.
+pub fn transform_onto(rect: egui::Rect) -> TSTransform {
+    TSTransform {
         scaling: rect.width() / ONLY_SUPPORTED_EXTENT as f32,
         translation: rect.min.to_vec2(),
-    };
-
-    let mut result = shapes.to_vec();
-    for shape in result.iter_mut() {
-        shape.transform(transform);
     }
-    result
 }
 
 fn get_layer_features(

--- a/walkers/src/render.rs
+++ b/walkers/src/render.rs
@@ -21,7 +21,7 @@ use lyon_tessellation::{
 use crate::{
     expression::Context,
     style::{Layout, Paint},
-    text::{OccupiedAreas, Text, draw_text},
+    text::Text,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -30,43 +30,27 @@ pub enum Error {
     Tessellation(#[from] TessellationError),
 }
 
-#[derive(Debug, Clone)]
-pub enum ShapeOrText {
-    Shape(Shape),
-    Text(Text),
+pub(crate) fn transformed_shapes(shapes: &[Shape], transform: TSTransform) -> Vec<Shape> {
+    let mut shapes = shapes.to_vec();
+
+    for shape in shapes.iter_mut() {
+        shape.transform(transform);
+
+        // `line-width` is in screen pixels, so a stroke must not follow the scaling.
+        keep_stroke_width(shape, transform.scaling);
+    }
+
+    shapes
 }
 
-impl From<Shape> for ShapeOrText {
-    fn from(shape: Shape) -> Self {
-        ShapeOrText::Shape(shape)
-    }
-}
-
-impl From<Mesh> for ShapeOrText {
-    fn from(mesh: Mesh) -> Self {
-        ShapeOrText::Shape(Shape::Mesh(mesh.into()))
-    }
-}
-
-impl ShapeOrText {
-    /// Move a shape from the space it was rendered in onto the screen.
-    ///
-    /// Geometry scales, stroke widths do not: a `line-width` of 4 means four pixels on the
-    /// screen at any zoom, the way the style spec means it, rather than four pixels only at
-    /// whichever zoom the tile happened to be rendered for. Text has always worked this way,
-    /// since its font size is not scaled either.
-    pub fn transform(&mut self, transform: TSTransform) {
-        match self {
-            ShapeOrText::Shape(shape) => {
-                shape.transform(transform);
-                keep_stroke_width(shape, transform.scaling);
-            }
-            ShapeOrText::Text(Text { position, .. }) => {
-                *position *= transform.scaling;
-                *position += transform.translation;
-            }
-        }
-    }
+pub(crate) fn transformed_texts(texts: &[Text], transform: TSTransform) -> Vec<Text> {
+    texts
+        .iter()
+        .map(|text| Text {
+            position: text.position * transform.scaling + transform.translation,
+            ..text.to_owned()
+        })
+        .collect()
 }
 
 /// Undo what [`Shape::transform`] did to the stroke widths, which it scales along with
@@ -93,30 +77,6 @@ fn keep_stroke_width(shape: &mut Shape, scaling: f32) {
     }
 }
 
-/// Lay out the labels, dropping the ones which would land on top of an already placed one.
-pub fn resolve_text(shapes: Vec<ShapeOrText>, ctx: &egui::Context) -> Vec<Shape> {
-    let mut occupied_text_areas = OccupiedAreas::new();
-
-    // Need to collect it to avoid deadlock caused by `Painter::extend` and `fonts_mut`.
-    shapes
-        .into_iter()
-        .map(|shape_or_text| match shape_or_text {
-            ShapeOrText::Shape(shape) => shape,
-            ShapeOrText::Text(text) => draw_text(text, ctx, &mut occupied_text_areas),
-        })
-        .collect()
-}
-
-/// Same, for labels which have already been sorted out from the shapes they came with.
-pub(crate) fn place_texts(texts: Vec<Text>, ctx: &egui::Context) -> Vec<Shape> {
-    let mut occupied_text_areas = OccupiedAreas::new();
-
-    texts
-        .into_iter()
-        .map(|text| draw_text(text, ctx, &mut occupied_text_areas))
-        .collect()
-}
-
 pub(crate) fn geometry_type_to_str(geometry: &Geometry<f32>) -> &'static str {
     match geometry {
         Geometry::Point(_) | Geometry::MultiPoint(_) => "Point",
@@ -132,7 +92,7 @@ pub(crate) fn geometry_type_to_str(geometry: &Geometry<f32>) -> &'static str {
 pub fn render_line(
     geometry: &Geometry<f32>,
     context: &Context,
-    shapes: &mut Vec<ShapeOrText>,
+    shapes: &mut Vec<Shape>,
     paint: &Paint,
 ) -> Result<(), Error> {
     let width = if let Some(width) = &paint.line_width {
@@ -187,7 +147,7 @@ pub fn render_line(
 
 /// Push a polyline as one or more shapes, splitting it into dashes if `dasharray` is given.
 fn push_line(
-    shapes: &mut Vec<ShapeOrText>,
+    shapes: &mut Vec<Shape>,
     points: Vec<egui::Pos2>,
     stroke: Stroke,
     dasharray: Option<&[f32]>,
@@ -196,11 +156,11 @@ fn push_line(
         Some(pattern) if !pattern.is_empty() => {
             for segment in dash_polyline(&points, pattern, stroke.width) {
                 if segment.len() >= 2 {
-                    shapes.push(Shape::line(segment, stroke).into());
+                    shapes.push(Shape::line(segment, stroke));
                 }
             }
         }
-        _ => shapes.push(Shape::line(points, stroke).into()),
+        _ => shapes.push(Shape::line(points, stroke)),
     }
 }
 
@@ -263,7 +223,7 @@ fn dash_polyline(points: &[egui::Pos2], pattern: &[f32], width: f32) -> Vec<Vec<
 pub(crate) fn render_polygon(
     geometry: &Geometry<f32>,
     context: &Context,
-    shapes: &mut Vec<ShapeOrText>,
+    shapes: &mut Vec<Shape>,
     paint: &Paint,
 ) -> Result<(), Error> {
     let polygons: &[geo_types::Polygon<f32>] = match geometry {
@@ -293,7 +253,9 @@ pub(crate) fn render_polygon(
             .iter()
             .map(|hole| lyon_points(&hole.0))
             .collect::<Vec<_>>();
-        shapes.push(tessellate_polygon(&exterior, &interiors, fill_color)?.into());
+        shapes.push(Shape::Mesh(
+            tessellate_polygon(&exterior, &interiors, fill_color)?.into(),
+        ));
     }
 
     Ok(())
@@ -302,26 +264,26 @@ pub(crate) fn render_polygon(
 pub fn render_symbol(
     geometry: &Geometry<f32>,
     context: &Context,
-    shapes: &mut Vec<ShapeOrText>,
+    texts: &mut Vec<Text>,
     layout: &Layout,
     paint: &Option<Paint>,
 ) -> Result<(), Error> {
     match geometry {
         Geometry::Point(point) => {
-            label_points(std::slice::from_ref(point), context, shapes, layout, paint)
+            label_points(std::slice::from_ref(point), context, texts, layout, paint)
         }
         Geometry::MultiPoint(multi_point) => {
-            label_points(&multi_point.0, context, shapes, layout, paint)
+            label_points(&multi_point.0, context, texts, layout, paint)
         }
         Geometry::LineString(line_string) => label_line_strings(
             std::slice::from_ref(line_string),
             context,
-            shapes,
+            texts,
             layout,
             paint,
         ),
         Geometry::MultiLineString(multi_line_string) => {
-            label_line_strings(&multi_line_string.0, context, shapes, layout, paint)
+            label_line_strings(&multi_line_string.0, context, texts, layout, paint)
         }
         _ => (),
     }
@@ -331,7 +293,7 @@ pub fn render_symbol(
 fn label_points(
     points: &[geo_types::Point<f32>],
     context: &Context,
-    shapes: &mut Vec<ShapeOrText>,
+    texts: &mut Vec<Text>,
     layout: &Layout,
     paint: &Option<Paint>,
 ) {
@@ -342,22 +304,22 @@ fn label_points(
     let text_size = evaluate_text_size(layout, context);
     let text_color = evaluate_text_color(paint, context);
 
-    shapes.extend(points.iter().map(|p| {
-        ShapeOrText::Text(Text::new(
+    texts.extend(points.iter().map(|p| {
+        Text::new(
             pos2(p.x(), p.y()),
             text.clone(),
             text_size,
             text_color,
             Color32::TRANSPARENT,
             0.0,
-        ))
+        )
     }))
 }
 
 fn label_line_strings(
     line_strings: &[geo_types::LineString<f32>],
     context: &Context,
-    shapes: &mut Vec<ShapeOrText>,
+    texts: &mut Vec<Text>,
     layout: &Layout,
     paint: &Option<Paint>,
 ) {
@@ -384,7 +346,7 @@ fn label_line_strings(
             let mid_point = midpoint(&line.start_point(), &line.end_point());
             let angle = line.slope().atan();
 
-            shapes.push(ShapeOrText::Text(Text::new(
+            texts.push(Text::new(
                 pos2(mid_point.x(), mid_point.y()),
                 text.clone(),
                 text_size,
@@ -392,7 +354,7 @@ fn label_line_strings(
                 // TODO: Implement real halo rendering.
                 text_halo_color.gamma_multiply(0.5),
                 angle,
-            )));
+            ));
         }
     }
 }
@@ -525,7 +487,7 @@ mod tests {
         assert_eq!(segments, vec![vec![pos2(0.0, 0.0), pos2(4.0, 0.0)]]);
     }
 
-    fn label(geometry: Geometry<f32>) -> Vec<ShapeOrText> {
+    fn label(geometry: Geometry<f32>) -> Vec<Text> {
         let context = Context::new(
             geometry_type_to_str(&geometry).to_string(),
             HashMap::from([("name".to_string(), serde_json::Value::from("Śnieżka"))]),
@@ -537,19 +499,13 @@ mod tests {
             text_size: None,
         };
 
-        let mut shapes = Vec::new();
-        render_symbol(&geometry, &context, &mut shapes, &layout, &None).unwrap();
-        shapes
+        let mut texts = Vec::new();
+        render_symbol(&geometry, &context, &mut texts, &layout, &None).unwrap();
+        texts
     }
 
-    fn texts(shapes: &[ShapeOrText]) -> Vec<&str> {
-        shapes
-            .iter()
-            .filter_map(|shape| match shape {
-                ShapeOrText::Text(text) => Some(text.text.as_str()),
-                ShapeOrText::Shape(_) => None,
-            })
-            .collect()
+    fn texts(texts: &[Text]) -> Vec<&str> {
+        texts.iter().map(|text| text.text.as_str()).collect()
     }
 
     /// MVT hands over `MultiPoint`, GeoJSON a plain `Point`, and both need labelling.
@@ -586,15 +542,15 @@ mod tests {
     /// Labels are placed on the geometry, not at the origin.
     #[test]
     fn a_point_label_lands_on_the_point() {
-        let shapes = label(Geometry::Point(geo_types::Point::new(1.0, 2.0)));
+        let texts = label(Geometry::Point(geo_types::Point::new(1.0, 2.0)));
 
-        match shapes.as_slice() {
-            [ShapeOrText::Text(text)] => assert_eq!(text.position, pos2(1.0, 2.0)),
+        match texts.as_slice() {
+            [text] => assert_eq!(text.position, pos2(1.0, 2.0)),
             other => panic!("expected a single label, got {other:?}"),
         }
     }
 
-    fn fill(geometry: Geometry<f32>) -> Vec<ShapeOrText> {
+    fn fill(geometry: Geometry<f32>) -> Vec<Shape> {
         let context = Context::new(
             geometry_type_to_str(&geometry).to_string(),
             HashMap::new(),
@@ -656,18 +612,19 @@ mod width_tests {
         let mut shapes = Vec::new();
         render_line(&geometry, &context, &mut shapes, &paint).unwrap();
 
-        for shape in shapes.iter_mut() {
-            shape.transform(TSTransform {
+        let shapes = transformed_shapes(
+            &shapes,
+            TSTransform {
                 scaling,
                 translation: Default::default(),
-            });
-        }
+            },
+        );
 
         shapes
             .iter()
             .find_map(|shape| match shape {
-                ShapeOrText::Shape(Shape::LineSegment { stroke, .. }) => Some(stroke.width),
-                ShapeOrText::Shape(Shape::Path(path)) => Some(path.stroke.width),
+                Shape::LineSegment { stroke, .. } => Some(stroke.width),
+                Shape::Path(path) => Some(path.stroke.width),
                 _ => None,
             })
             .expect("no line")
@@ -696,16 +653,17 @@ mod width_tests {
 
         let mut shapes = Vec::new();
         render_line(&geometry, &context, &mut shapes, &Paint::default()).unwrap();
-        for shape in shapes.iter_mut() {
-            shape.transform(TSTransform {
+        let shapes = transformed_shapes(
+            &shapes,
+            TSTransform {
                 scaling: 256.0 / 4096.0,
                 translation: Default::default(),
-            });
-        }
+            },
+        );
 
         let points = match &shapes[0] {
-            ShapeOrText::Shape(Shape::LineSegment { points, .. }) => points.to_vec(),
-            ShapeOrText::Shape(Shape::Path(path)) => path.points.to_vec(),
+            Shape::LineSegment { points, .. } => points.to_vec(),
+            Shape::Path(path) => path.points.to_vec(),
             other => panic!("expected a line, got {other:?}"),
         };
 

--- a/walkers/src/text.rs
+++ b/walkers/src/text.rs
@@ -106,11 +106,7 @@ impl OccupiedAreas {
 }
 
 /// Lay the text out, unless it would land on an area which is already taken.
-pub fn draw_text(
-    text: Text,
-    ctx: &egui::Context,
-    occupied_text_areas: &mut OccupiedAreas,
-) -> Shape {
+fn place_text(text: Text, ctx: &egui::Context, occupied_text_areas: &mut OccupiedAreas) -> Shape {
     use egui::epaint::TextShape;
 
     let mut layout_job = egui::text::LayoutJob::default();
@@ -138,4 +134,15 @@ pub fn draw_text(
     } else {
         Shape::Noop
     }
+}
+
+/// Lay out the labels, dropping the ones which would land on top of an already placed one.
+pub fn place_texts(texts: Vec<Text>, ctx: &egui::Context) -> Vec<Shape> {
+    let mut occupied_text_areas = OccupiedAreas::new();
+
+    // Need to collect it to avoid deadlock caused by `Painter::extend` and `fonts_mut`.
+    texts
+        .into_iter()
+        .map(|text| place_text(text, ctx, &mut occupied_text_areas))
+        .collect()
 }

--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "mvt")]
 use crate::mvt;
 #[cfg(feature = "mvt")]
-use crate::render::{self, ShapeOrText};
+use crate::render;
 
 use egui::{Color32, Context, Mesh, Rect, Vec2, pos2};
 use egui::{ColorImage, TextureHandle};
@@ -108,7 +108,10 @@ pub trait Tiles {
 pub enum Tile {
     Raster(TextureHandle),
     #[cfg(feature = "mvt")]
-    Vector(Vec<ShapeOrText>),
+    Vector {
+        shapes: Vec<egui::Shape>,
+        texts: Vec<crate::text::Text>,
+    },
 }
 
 impl Tile {
@@ -148,7 +151,8 @@ impl Tile {
 
     #[cfg(feature = "mvt")]
     pub fn from_mvt(data: &[u8], style: &Style, zoom: u8) -> Result<Self, TileError> {
-        Ok(Self::Vector(mvt::render(data, style, zoom)?))
+        let (shapes, texts) = mvt::render(data, style, zoom)?;
+        Ok(Self::Vector { shapes, texts })
     }
 
     /// Load the texture from egui's [`ColorImage`].
@@ -176,21 +180,21 @@ impl Tile {
                 painter.add(egui::Shape::mesh(mesh));
             }
             #[cfg(feature = "mvt")]
-            Tile::Vector(shapes) => {
+            Tile::Vector {
+                shapes,
+                texts: from_tile,
+            } => {
                 // Renderer needs to work on the full tile, before it was clipped with `uv`...
                 let full_rect = full_rect_of_clipped_tile(rect, uv);
 
                 // ...and then it can be clipped to the `rect`.
                 let painter = painter.with_clip_rect(rect);
 
-                for shape in mvt::transformed(shapes, full_rect) {
-                    match shape {
-                        ShapeOrText::Shape(shape) => {
-                            painter.add(shape);
-                        }
-                        ShapeOrText::Text(text) => texts.texts.push(text),
-                    }
-                }
+                let transform = mvt::transform_onto(full_rect);
+                painter.extend(render::transformed_shapes(shapes, transform));
+                texts
+                    .texts
+                    .extend(render::transformed_texts(from_tile, transform));
             }
         }
     }
@@ -209,7 +213,7 @@ impl Texts {
     /// layer.
     pub(crate) fn paint(self, painter: &egui::Painter) {
         #[cfg(feature = "mvt")]
-        painter.extend(render::place_texts(self.texts, painter.ctx()));
+        painter.extend(crate::text::place_texts(self.texts, painter.ctx()));
         #[cfg(not(feature = "mvt"))]
         let _ = painter;
     }
@@ -526,18 +530,21 @@ mod tests {
     impl Tiles for LabelAtBothEdges {
         fn at(&mut self, _tile_id: TileId) -> Option<TilePiece> {
             let label = |x: f32| {
-                ShapeOrText::Text(crate::text::Text::new(
+                crate::text::Text::new(
                     pos2(x, 2048.),
                     "Szczepankowice".to_string(),
                     12.,
                     Color32::BLACK,
                     Color32::TRANSPARENT,
                     0.,
-                ))
+                )
             };
 
             Some(TilePiece::new(
-                Tile::Vector(vec![label(0.), label(4096.)]),
+                Tile::Vector {
+                    shapes: Vec::new(),
+                    texts: vec![label(0.), label(4096.)],
+                },
                 Rect::from_min_max(pos2(0., 0.), pos2(1., 1.)),
             ))
         }
@@ -597,7 +604,7 @@ mod tests {
             positions.len()
         );
 
-        let placed = crate::render::place_texts(texts.texts, &ctx)
+        let placed = crate::text::place_texts(texts.texts, &ctx)
             .into_iter()
             .filter(|shape| !matches!(shape, egui::Shape::Noop))
             .count();

--- a/walkers_extras/src/geojson.rs
+++ b/walkers_extras/src/geojson.rs
@@ -8,7 +8,7 @@ use log::warn;
 use rstar::primitives::{GeomWithData, Rectangle};
 use rstar::{AABB, RTree};
 use walkers::{
-    Context, Filter, Layer, Position, Projector, Style, render_line, render_symbol, resolve_text,
+    Context, Filter, Layer, Position, Projector, Style, place_texts, render_line, render_symbol,
 };
 
 struct Feature {
@@ -55,6 +55,7 @@ impl GeoJsonLayer {
         let viewport = viewport(projector, ui.clip_rect());
 
         let mut shapes = Vec::new();
+        let mut texts = Vec::new();
 
         for layer in &self.style.layers {
             match layer {
@@ -72,7 +73,7 @@ impl GeoJsonLayer {
                 } => {
                     for (geometry, context) in self.features(viewport, filter.as_ref(), zoom) {
                         let projected = project_geometry(geometry, projector);
-                        let _ = render_symbol(&projected, &context, &mut shapes, layout, paint);
+                        let _ = render_symbol(&projected, &context, &mut texts, layout, paint);
                     }
                 }
                 other => {
@@ -81,8 +82,11 @@ impl GeoJsonLayer {
             }
         }
 
-        let shapes = resolve_text(shapes, ui.ctx());
-        ui.painter().extend(shapes);
+        // Geometry first, then the labels on top of it.
+        let texts = place_texts(texts, ui.ctx());
+        let painter = ui.painter();
+        painter.extend(shapes);
+        painter.extend(texts);
     }
 
     /// Features in the viewport which the layer's filter lets through.


### PR DESCRIPTION
Nothing ever produced both: lines and fills make shapes, symbols make text. `ShapeOrText` existed only because the two shared a sink, which meant every caller had to sort them out again — `Tile::draw` did it per shape, every frame.

Each renderer now writes to the sink it fills, and `Tile::Vector` carries the two separately. That leaves `resolve_text` with nothing to resolve, so it becomes `place_texts` and joins the collision machinery it belongs with in `text.rs`; `place_text` next to it stops pretending to draw, since it can return `Shape::Noop`.

`GeoJsonLayer` gets its labels painted above its geometry rather than interleaved, which fell out of the split.

Measured first: the enum was free — 64 bytes either way, same clone time. This is for reading, not for speed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
