### PR TITLE
Render tiles into pixels rather than their own extent

### DIFF
--- a/walkers/src/http_tiles.rs
+++ b/walkers/src/http_tiles.rs
@@ -55,7 +55,7 @@ impl HttpTiles {
             attribution,
             tiles_io: TilesIo::new(
                 HttpFetch::new(source, http_options),
-                EguiTileFactory::new(egui_ctx.clone(), style),
+                EguiTileFactory::new(egui_ctx.clone(), style, tile_size),
                 egui_ctx,
             ),
             tile_size,

--- a/walkers/src/local_tiles.rs
+++ b/walkers/src/local_tiles.rs
@@ -87,5 +87,11 @@ fn load(
         format!("{}.png", tile_id.y).into(),
     ]);
     let bytes = std::fs::read(path)?;
-    Ok(Tile::new(&bytes, &Style::default(), 10, egui_ctx)?)
+    Ok(Tile::new(
+        &bytes,
+        &Style::default(),
+        10,
+        crate::mercator::TILE_SIZE,
+        egui_ctx,
+    )?)
 }

--- a/walkers/src/mvt.rs
+++ b/walkers/src/mvt.rs
@@ -7,9 +7,11 @@ use log::warn;
 use mvt_reader::{Reader, feature::Value};
 use serde_json::{Number, Value as JsonValue};
 
+use geo::MapCoords;
+
 use crate::{
     expression::Context,
-    render::{self, Geometry},
+    render::{self, Coord, Geometry},
     style::{Filter, Layer, SourceLayer, Style},
     text::Text,
 };
@@ -31,7 +33,12 @@ impl From<mvt_reader::error::ParserError> for Error {
 const ONLY_SUPPORTED_EXTENT: u32 = 4096;
 
 /// Render MVT data into a list of [`epaint::Shape`]s.
-pub fn render(data: &[u8], style: &Style, zoom: u8) -> Result<(Vec<Shape>, Vec<Text>), Error> {
+pub fn render(
+    data: &[u8],
+    style: &Style,
+    zoom: u8,
+    tile_size: u32,
+) -> Result<(Vec<Shape>, Vec<Text>), Error> {
     let data = mvt_reader::Reader::new(data.to_vec())?;
     let mut shapes = Vec::new();
     let mut texts = Vec::new();
@@ -47,10 +54,8 @@ pub fn render(data: &[u8], style: &Style, zoom: u8) -> Result<(Vec<Shape>, Vec<T
                     Color32::WHITE
                 };
 
-                let rect = Rect::from_min_size(
-                    pos2(0.0, 0.0),
-                    vec2(ONLY_SUPPORTED_EXTENT as f32, ONLY_SUPPORTED_EXTENT as f32),
-                );
+                let rect =
+                    Rect::from_min_size(pos2(0.0, 0.0), vec2(tile_size as f32, tile_size as f32));
                 shapes.push(Shape::rect_filled(rect, 0.0, bg_color));
             }
             Layer::Fill {
@@ -59,7 +64,7 @@ pub fn render(data: &[u8], style: &Style, zoom: u8) -> Result<(Vec<Shape>, Vec<T
                 paint,
             } => {
                 for (geometry, context) in
-                    get_layer_features(&data, zoom, source_layer, filter.as_ref())?
+                    get_layer_features(&data, zoom, source_layer, filter.as_ref(), tile_size)?
                 {
                     if let Err(err) =
                         render::render_polygon(&geometry, &context, &mut shapes, paint)
@@ -74,7 +79,7 @@ pub fn render(data: &[u8], style: &Style, zoom: u8) -> Result<(Vec<Shape>, Vec<T
                 paint,
             } => {
                 for (geometry, context) in
-                    get_layer_features(&data, zoom, source_layer, filter.as_ref())?
+                    get_layer_features(&data, zoom, source_layer, filter.as_ref(), tile_size)?
                 {
                     if let Err(err) = render::render_line(&geometry, &context, &mut shapes, paint) {
                         warn!("{err}");
@@ -88,7 +93,7 @@ pub fn render(data: &[u8], style: &Style, zoom: u8) -> Result<(Vec<Shape>, Vec<T
                 paint,
             } => {
                 for (geometry, context) in
-                    get_layer_features(&data, zoom, source_layer, filter.as_ref())?
+                    get_layer_features(&data, zoom, source_layer, filter.as_ref(), tile_size)?
                 {
                     if let Err(err) =
                         render::render_symbol(&geometry, &context, &mut texts, layout, paint)
@@ -108,10 +113,10 @@ pub fn render(data: &[u8], style: &Style, zoom: u8) -> Result<(Vec<Shape>, Vec<T
     Ok((shapes, texts))
 }
 
-/// What takes a tile from MVT space onto the screen.
-pub fn transform_onto(rect: egui::Rect) -> TSTransform {
+/// What takes a tile rendered for `tile_size` onto the `rect` it is actually drawn at.
+pub fn transform_onto(rect: egui::Rect, tile_size: u32) -> TSTransform {
     TSTransform {
-        scaling: rect.width() / ONLY_SUPPORTED_EXTENT as f32,
+        scaling: rect.width() / tile_size as f32,
         translation: rect.min.to_vec2(),
     }
 }
@@ -121,7 +126,9 @@ fn get_layer_features(
     zoom: u8,
     source_layer: &SourceLayer,
     filter: Option<&Filter>,
+    tile_size: u32,
 ) -> Result<impl Iterator<Item = (Geometry<f32>, Context)>, Error> {
+    let into_pixels = tile_size as f32 / ONLY_SUPPORTED_EXTENT as f32;
     let mut matched = 0usize;
     let mut raw = Vec::new();
 
@@ -158,9 +165,14 @@ fn get_layer_features(
             zoom,
         );
 
+        let geometry = feature.geometry.map_coords(|coord| Coord {
+            x: coord.x * into_pixels,
+            y: coord.y * into_pixels,
+        });
+
         filter
             .is_none_or(|filter| filter.matches(&context))
-            .then_some((feature.geometry, context))
+            .then_some((geometry, context))
     });
 
     Ok(features)

--- a/walkers/src/pmtiles.rs
+++ b/walkers/src/pmtiles.rs
@@ -14,6 +14,10 @@ use std::{
 };
 use thiserror::Error;
 
+/// What a tile is rendered for, unless asked for something else. Larger means fewer tiles
+/// covering the map, at less detail.
+const DEFAULT_TILE_SIZE: u32 = 1024;
+
 /// Provides tiles from a local PMTiles file.
 ///
 /// <https://docs.protomaps.com/guide/getting-started>
@@ -30,19 +34,26 @@ impl PmTiles {
     /// Construct new [`PmTiles`] with [`Style`]. Style is relevant only for vector tile
     /// sources.
     pub fn with_style(path: impl AsRef<Path>, style: Style, egui_ctx: Context) -> Self {
+        Self::with_style_and_tile_size(path, style, DEFAULT_TILE_SIZE, egui_ctx)
+    }
+
+    /// Tiles are rendered for `tile_size`, which is the size they are drawn at when the map is
+    /// at one of their zoom levels. Everything a style measures in pixels is measured against
+    /// it, so it has to be known before the first tile is decoded.
+    pub fn with_style_and_tile_size(
+        path: impl AsRef<Path>,
+        style: Style,
+        tile_size: u32,
+        egui_ctx: Context,
+    ) -> Self {
         Self {
             tiles_io: TilesIo::new(
                 PmTilesFetch::new(path.as_ref()),
-                EguiTileFactory::new(egui_ctx.clone(), style),
+                EguiTileFactory::new(egui_ctx.clone(), style, tile_size),
                 egui_ctx,
             ),
-            tile_size: 1024,
+            tile_size,
         }
-    }
-
-    pub fn with_tile_size(mut self, tile_size: u32) -> Self {
-        self.tile_size = tile_size;
-        self
     }
 
     /// Get at tile, or interpolate it from lower zoom levels. This function does not start any

--- a/walkers/src/tiles.rs
+++ b/walkers/src/tiles.rs
@@ -117,9 +117,15 @@ pub enum Tile {
 impl Tile {
     /// Create a tile from raw image data. The data can be either raster image (PNG, JPEG, etc.)
     /// or vector tile (MVT) if the `mvt` feature is enabled.
-    pub fn new(image: &[u8], style: &Style, zoom: u8, ctx: &Context) -> Result<Self, TileError> {
+    pub fn new(
+        image: &[u8],
+        style: &Style,
+        zoom: u8,
+        tile_size: u32,
+        ctx: &Context,
+    ) -> Result<Self, TileError> {
         #[cfg(not(feature = "mvt"))]
-        let _ = (style, zoom);
+        let _ = (style, zoom, tile_size);
 
         if image.is_empty() {
             return Err(TileError::Empty);
@@ -140,7 +146,7 @@ impl Tile {
             #[cfg(feature = "mvt")]
             {
                 log::debug!("Trying to decode tile as MVT vector tile.");
-                Ok(Self::from_mvt(image, style, zoom)?)
+                Ok(Self::from_mvt(image, style, zoom, tile_size)?)
             }
             #[cfg(not(feature = "mvt"))]
             {
@@ -150,8 +156,13 @@ impl Tile {
     }
 
     #[cfg(feature = "mvt")]
-    pub fn from_mvt(data: &[u8], style: &Style, zoom: u8) -> Result<Self, TileError> {
-        let (shapes, texts) = mvt::render(data, style, zoom)?;
+    pub fn from_mvt(
+        data: &[u8],
+        style: &Style,
+        zoom: u8,
+        tile_size: u32,
+    ) -> Result<Self, TileError> {
+        let (shapes, texts) = mvt::render(data, style, zoom, tile_size)?;
         Ok(Self::Vector { shapes, texts })
     }
 
@@ -168,10 +179,11 @@ impl Tile {
         rect: Rect,
         uv: Rect,
         transparency: f32,
+        tile_size: u32,
         texts: &mut Texts,
     ) {
         #[cfg(not(feature = "mvt"))]
-        let _ = texts;
+        let _ = (tile_size, texts);
 
         match self {
             Tile::Raster(texture_handle) => {
@@ -190,7 +202,7 @@ impl Tile {
                 // ...and then it can be clipped to the `rect`.
                 let painter = painter.with_clip_rect(rect);
 
-                let transform = mvt::transform_onto(full_rect);
+                let transform = mvt::transform_onto(full_rect, tile_size);
                 painter.extend(render::transformed_shapes(shapes, transform));
                 texts
                     .texts
@@ -295,6 +307,7 @@ fn flood_fill_tiles(
                 rect(tile_screen_position, corrected_tile_size),
                 tile.uv,
                 transparency,
+                tiles.tile_size(),
                 texts,
             )
         }
@@ -363,17 +376,22 @@ pub(crate) fn rect(screen_position: Vec2, tile_size: f64) -> Rect {
 pub struct EguiTileFactory {
     egui_ctx: Context,
     style: Style,
+    tile_size: u32,
 }
 
 impl EguiTileFactory {
-    pub fn new(egui_ctx: Context, style: Style) -> Self {
-        Self { egui_ctx, style }
+    pub fn new(egui_ctx: Context, style: Style, tile_size: u32) -> Self {
+        Self {
+            egui_ctx,
+            style,
+            tile_size,
+        }
     }
 }
 
 impl TileFactory for EguiTileFactory {
     fn create_tile(&self, data: &bytes::Bytes, zoom: u8) -> Result<Tile, TileError> {
-        Tile::new(data, &self.style, zoom, &self.egui_ctx)
+        Tile::new(data, &self.style, zoom, self.tile_size, &self.egui_ctx)
     }
 }
 
@@ -522,7 +540,8 @@ mod tests {
     }
 
     /// A source whose every tile carries the same label at both its left and right edge, the
-    /// way vector tiles repeat features which fall near a boundary.
+    /// way vector tiles repeat features which fall near a boundary. Positions are in the
+    /// pixels of a tile, which is what a rendered tile holds.
     #[cfg(feature = "mvt")]
     struct LabelAtBothEdges;
 
@@ -531,7 +550,7 @@ mod tests {
         fn at(&mut self, _tile_id: TileId) -> Option<TilePiece> {
             let label = |x: f32| {
                 crate::text::Text::new(
-                    pos2(x, 2048.),
+                    pos2(x, TILE_SIZE as f32 / 2.),
                     "Szczepankowice".to_string(),
                     12.,
                     Color32::BLACK,
@@ -543,7 +562,7 @@ mod tests {
             Some(TilePiece::new(
                 Tile::Vector {
                     shapes: Vec::new(),
-                    texts: vec![label(0.), label(4096.)],
+                    texts: vec![label(0.), label(TILE_SIZE as f32)],
                 },
                 Rect::from_min_max(pos2(0., 0.), pos2(1., 1.)),
             ))

--- a/wanderers/src/map_style.rs
+++ b/wanderers/src/map_style.rs
@@ -417,7 +417,7 @@ fn build(palette: &Palette, schema: Schema) -> Style {
             ]))),
             paint: Paint {
                 line_color: Some(Color(json!(palette.tunnel_casing))),
-                line_dasharray: Some(Dasharray(json!([3, 2]))),
+                line_dasharray: Some(Dasharray(json!([2, 2]))),
                 line_width: Some(linear_zoom_interpolation(&[(12.0, 0.0), (12.5, 1.0)])),
                 ..Default::default()
             },
@@ -432,7 +432,7 @@ fn build(palette: &Palette, schema: Schema) -> Style {
             ]))),
             paint: Paint {
                 line_color: Some(Color(json!(palette.tunnel_casing))),
-                line_dasharray: Some(Dasharray(json!([3, 2]))),
+                line_dasharray: Some(Dasharray(json!([2, 2]))),
                 line_width: Some(linear_zoom_interpolation(&[(12.0, 0.0), (12.5, 1.0)])),
                 ..Default::default()
             },
@@ -448,7 +448,7 @@ fn build(palette: &Palette, schema: Schema) -> Style {
             ]))),
             paint: Paint {
                 line_color: Some(Color(json!(palette.tunnel_casing))),
-                line_dasharray: Some(Dasharray(json!([3, 2]))),
+                line_dasharray: Some(Dasharray(json!([2, 2]))),
                 line_width: Some(linear_zoom_interpolation(&[(9.0, 0.0), (9.5, 1.0)])),
                 ..Default::default()
             },
@@ -465,7 +465,7 @@ fn build(palette: &Palette, schema: Schema) -> Style {
             ]))),
             paint: Paint {
                 line_color: Some(Color(json!(palette.tunnel_casing))),
-                line_dasharray: Some(Dasharray(json!([6, 0.5]))),
+                line_dasharray: Some(Dasharray(json!([2, 2]))),
                 line_width: Some(linear_zoom_interpolation(&[
                     (7.0, 0.0),
                     (7.5, 1.5),
@@ -484,7 +484,7 @@ fn build(palette: &Palette, schema: Schema) -> Style {
             ]))),
             paint: Paint {
                 line_color: Some(Color(json!(palette.structure))),
-                line_dasharray: Some(Dasharray(json!([4.5, 0.5]))),
+                line_dasharray: Some(Dasharray(json!([2, 2]))),
                 line_width: Some(linear_zoom_interpolation(&[(14.0, 0.0), (20.0, 7.0)])),
                 ..Default::default()
             },
@@ -805,7 +805,7 @@ fn build(palette: &Palette, schema: Schema) -> Style {
             paint: Paint {
                 line_opacity: Some(Float(json!(0.5))),
                 line_color: Some(Color(json!(palette.rail_tie))),
-                line_dasharray: Some(Dasharray(json!([4, 1]))),
+                line_dasharray: Some(Dasharray(json!([2, 2]))),
                 line_width: Some(linear_zoom_interpolation(&[(3.0, 0.0), (18.0, 2.0)])),
                 ..Default::default()
             },
@@ -892,7 +892,7 @@ fn build(palette: &Palette, schema: Schema) -> Style {
             ]))),
             paint: Paint {
                 line_color: Some(Color(json!(palette.bridge))),
-                line_dasharray: Some(Dasharray(json!([2, 1]))),
+                line_dasharray: Some(Dasharray(json!([2, 2]))),
                 line_width: Some(linear_zoom_interpolation(&[(14.0, 0.0), (20.0, 7.0)])),
                 ..Default::default()
             },


### PR DESCRIPTION
A dash pattern is given in multiples of the line's width, and a line's width is a number of screen pixels. The geometry it was measured along was in the tile's extent, so the two never met — on a tile drawn 1024px across, a dash meant to be 8px came out at 2px, and the line was cut into four times as many pieces as it should have been.

Tiles are now rendered into the pixels of the size they are drawn at, so a style's lengths mean the same thing here as anywhere else and nothing is converted on the way. `GeoJsonLayer` already worked this way, so the two paths now agree rather than one compensating.

Which size that is has to be known before the first tile is decoded, so it goes to the source's constructor. `PmTiles::with_tile_size` is replaced by `with_style_and_tile_size` — a setter could not be honest here, since tiles decoded before the call would be in one space and those after it in another.

For one OpenFreeMap tile through `openfreemap_bright`: **64,565 shapes down to 9,183**, and the per-frame cost of that tile from ~17ms to ~2ms. Most of the difference is dashes that should never have been that short.

Breaking: `Tile::new` and `Tile::from_mvt` take a `tile_size`, and `PmTiles::with_tile_size` is gone.

Wanderers' dash patterns are evened out to match, having been drawn against the old scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
