### PR TITLE
Draw buildings and country borders on OpenMapTiles too

### DIFF
--- a/wanderers/src/map_style.rs
+++ b/wanderers/src/map_style.rs
@@ -21,6 +21,7 @@ pub struct Schema {
     boundaries: &'static str,
     kind: &'static str,
     kind_detail: &'static str,
+    admin_level: &'static str,
     place_rank: &'static str,
     brunnel: Option<&'static str>,
     link: &'static str,
@@ -40,6 +41,7 @@ pub const PROTOMAPS: Schema = Schema {
     boundaries: "boundaries",
     kind: "kind",
     kind_detail: "kind_detail",
+    admin_level: "kind_detail",
     place_rank: "population_rank",
     brunnel: None,
     link: "is_link",
@@ -60,6 +62,7 @@ pub const OPENMAPTILES: Schema = Schema {
     boundaries: "boundary",
     kind: "class",
     kind_detail: "subclass",
+    admin_level: "admin_level",
     place_rank: "rank",
     brunnel: Some("brunnel"),
     link: "ramp",
@@ -570,10 +573,9 @@ fn build(palette: &Palette, schema: Schema) -> Style {
         Layer::Fill {
             source_layer: schema.buildings.into(),
             filter: Some(Filter(json!([
-                "in",
-                schema.kind,
-                "building",
-                "building_part"
+                "any",
+                ["in", schema.kind, "building", "building_part"],
+                ["!has", schema.kind]
             ]))),
             paint: Paint {
                 fill_color: Some(Color(json!(palette.structure))),
@@ -813,7 +815,7 @@ fn build(palette: &Palette, schema: Schema) -> Style {
         // boundaries_country
         Layer::Line {
             source_layer: schema.boundaries.into(),
-            filter: Some(Filter(json!(["<=", schema.kind_detail, 2]))),
+            filter: Some(Filter(json!(["<=", schema.admin_level, 2]))),
             paint: Paint {
                 line_color: Some(Color(json!(palette.label))),
                 line_width: Some(Float(json!(2))),


### PR DESCRIPTION
Two separate reasons the same style draws less on OpenFreeMap than it does on Protomaps.

**Buildings.** OpenMapTiles does not sort them — the layer carries `render_height` and nothing to classify by — so `["in", class, "building", "building_part"]` matched none of the 2,723 buildings in a tile of Wrocław. The filter now also accepts a building with no kind at all:

```rust
["any",
  ["in", schema.kind, "building", "building_part"],
  ["!has", schema.kind]]
```

**Country borders.** Boundaries are graded by `admin_level` there, not by the detail of their kind, so the filter was reading a property which does not exist. `Schema` now says which one to ask for. Checked against a tile straddling the Polish–Czech border, where `admin_level <= 2` finds it and the old filter found nothing — a tile of Wrocław only carries levels 9 and 10, so it could not have shown this.

One tile through the whole style: **13,101 shapes against 10,378 before**. Protomaps is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
