### PR TITLE
Name a street once, not once per feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 * `line-width` is now in screen pixels, so lines are thicker than before.
 * Labels are placed against the whole map rather than one tile at a time, so they no longer
   repeat or get cut off at tile boundaries. They are also drawn above every layer.
+* A street split into many features is named once rather than once per feature.
 
 ## 0.58.0
 

--- a/walkers/src/lib.rs
+++ b/walkers/src/lib.rs
@@ -61,6 +61,6 @@ pub use style::{
     linear_zoom_interpolation,
 };
 #[cfg(feature = "mvt")]
-pub use text::{Text, place_texts};
+pub use text::{Placement, Text, place_texts};
 pub use tiles::{Tile, TileId, TilePiece, Tiles};
 pub use zoom::InvalidZoom;

--- a/walkers/src/render.rs
+++ b/walkers/src/render.rs
@@ -21,7 +21,7 @@ use lyon_tessellation::{
 use crate::{
     expression::Context,
     style::{Layout, Paint},
-    text::Text,
+    text::{Placement, Text},
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -342,7 +342,8 @@ fn label_line_strings(
                     text_color,
                     angle,
                 )
-                .with_halo(halo_color, halo_width),
+                .with_halo(halo_color, halo_width)
+                .with_placement(Placement::Line),
             );
         }
     }

--- a/walkers/src/text.rs
+++ b/walkers/src/text.rs
@@ -1,5 +1,15 @@
 use egui::{Color32, Pos2, Shape, Vec2, vec2};
 use geo::{BoundingRect, Coord, Intersects, LineString, Polygon};
+use std::collections::HashMap;
+
+/// What the label names, which decides whether it may be said again nearby. Mirrors MapLibre's
+/// `symbol-placement`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Placement {
+    #[default]
+    Point,
+    Line,
+}
 
 #[derive(Debug, Clone)]
 pub struct Text {
@@ -10,6 +20,7 @@ pub struct Text {
     pub halo_color: Color32,
     pub halo_width: f32,
     pub angle: f32,
+    pub placement: Placement,
 }
 
 impl Text {
@@ -28,12 +39,18 @@ impl Text {
             halo_color: Color32::TRANSPARENT,
             halo_width: 0.0,
             angle,
+            placement: Placement::Point,
         }
     }
 
     pub fn with_halo(mut self, color: Color32, width: f32) -> Self {
         self.halo_color = color;
         self.halo_width = width;
+        self
+    }
+
+    pub fn with_placement(mut self, placement: Placement) -> Self {
+        self.placement = placement;
         self
     }
 }
@@ -104,6 +121,42 @@ impl OrientedRect {
     }
 }
 
+/// How far apart two labels saying the same thing have to be.
+const MIN_REPEAT_DISTANCE: f32 = 400.0;
+
+/// Tracks what has been named where, so that a street arriving as a dozen features is not
+/// named a dozen times.
+///
+/// Only line labels take part. OSM splits a way at every intersection, so one street really is
+/// many features saying the same thing, while two points sharing a name are two different
+/// things - house numbers being the obvious case.
+#[derive(Default)]
+struct PlacedLabels {
+    positions: HashMap<String, Vec<Pos2>>,
+}
+
+impl PlacedLabels {
+    fn text_already_placed_nearby(&self, text: &Text) -> bool {
+        text.placement == Placement::Line
+            && self.positions.get(&text.text).is_some_and(|positions| {
+                positions
+                    .iter()
+                    .any(|placed| placed.distance(text.position) < MIN_REPEAT_DISTANCE)
+            })
+    }
+
+    fn remember(&mut self, text: &Text) {
+        if text.placement != Placement::Line {
+            return;
+        }
+
+        self.positions
+            .entry(text.text.to_owned())
+            .or_default()
+            .push(text.position);
+    }
+}
+
 // Tracks areas occupied by texts to avoid overlapping them.
 pub struct OccupiedAreas {
     areas: Vec<OrientedRect>,
@@ -124,9 +177,20 @@ impl OccupiedAreas {
     }
 }
 
-/// Lay the text out, unless it would land on an area which is already taken.
-fn place_text(text: Text, ctx: &egui::Context, occupied_text_areas: &mut OccupiedAreas) -> Shape {
+/// Lay the text out, unless it repeats a nearby one or would land on an area which is already
+/// taken.
+fn place_text(
+    text: Text,
+    ctx: &egui::Context,
+    occupied_areas: &mut OccupiedAreas,
+    placed_labels: &mut PlacedLabels,
+) -> Shape {
     use egui::epaint::TextShape;
+
+    // Before laying it out, which is the expensive part.
+    if placed_labels.text_already_placed_nearby(&text) {
+        return Shape::Noop;
+    }
 
     let mut layout_job = egui::text::LayoutJob::default();
 
@@ -145,9 +209,11 @@ fn place_text(text: Text, ctx: &egui::Context, occupied_text_areas: &mut Occupie
     let area = OrientedRect::new(text.position, text.angle, galley.size());
     let top_left = area.top_left();
 
-    if !occupied_text_areas.try_occupy(area) {
+    if !occupied_areas.try_occupy(area) {
         return Shape::Noop;
     }
+
+    placed_labels.remember(&text);
 
     let on_top =
         TextShape::new(top_left, galley.to_owned(), text.text_color).with_angle(text.angle);
@@ -175,13 +241,88 @@ fn place_text(text: Text, ctx: &egui::Context, occupied_text_areas: &mut Occupie
     Shape::Vec(shapes)
 }
 
-/// Lay out the labels, dropping the ones which would land on top of an already placed one.
+/// Lay out the labels, dropping the ones which repeat a nearby label or would land on top of an
+/// already placed one.
 pub fn place_texts(texts: Vec<Text>, ctx: &egui::Context) -> Vec<Shape> {
-    let mut occupied_text_areas = OccupiedAreas::new();
+    let mut occupied_areas = OccupiedAreas::new();
+    let mut placed_labels = PlacedLabels::default();
 
     // Need to collect it to avoid deadlock caused by `Painter::extend` and `fonts_mut`.
     texts
         .into_iter()
-        .map(|text| place_text(text, ctx, &mut occupied_text_areas))
+        .map(|text| place_text(text, ctx, &mut occupied_areas, &mut placed_labels))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use egui::pos2;
+
+    fn context() -> egui::Context {
+        let ctx = egui::Context::default();
+        // Fonts only exist once a pass has been run.
+        let mut output = ctx.run_ui(egui::RawInput::default(), |_| {});
+        output.textures_delta.clear();
+        ctx
+    }
+
+    /// Stacked vertically, so that whatever rejects them is the repeat rule rather than the
+    /// collision one.
+    fn column(name: &str, spacing: f32, placement: Placement) -> Vec<Text> {
+        (0..2)
+            .map(|n| {
+                Text::new(
+                    pos2(0., n as f32 * spacing),
+                    name.to_string(),
+                    12.,
+                    Color32::BLACK,
+                    0.,
+                )
+                .with_placement(placement)
+            })
+            .collect()
+    }
+
+    fn count_placed(texts: Vec<Text>, ctx: &egui::Context) -> usize {
+        place_texts(texts, ctx)
+            .into_iter()
+            .filter(|shape| !matches!(shape, Shape::Noop))
+            .count()
+    }
+
+    #[test]
+    fn a_street_name_is_not_repeated_within_the_repeat_distance() {
+        let ctx = context();
+        let texts = column("Szczepankowice", MIN_REPEAT_DISTANCE / 2., Placement::Line);
+
+        assert_eq!(count_placed(texts, &ctx), 1);
+    }
+
+    #[test]
+    fn a_street_name_is_said_again_once_far_enough_away() {
+        let ctx = context();
+        let texts = column("Szczepankowice", MIN_REPEAT_DISTANCE * 2., Placement::Line);
+
+        assert_eq!(count_placed(texts, &ctx), 2);
+    }
+
+    #[test]
+    fn different_street_names_may_sit_close_together() {
+        let ctx = context();
+        let mut texts = column("Szczepankowice", MIN_REPEAT_DISTANCE / 2., Placement::Line);
+        texts[1].text = "Wrocław".to_string();
+
+        assert_eq!(count_placed(texts, &ctx), 2);
+    }
+
+    /// Two houses may well share a number, so unlike a street split into many features, they
+    /// are not the same thing said twice.
+    #[test]
+    fn neighbouring_houses_keep_the_same_number() {
+        let ctx = context();
+        let texts = column("5", MIN_REPEAT_DISTANCE / 2., Placement::Point);
+
+        assert_eq!(count_placed(texts, &ctx), 2);
+    }
 }

--- a/walkers/src/text.rs
+++ b/walkers/src/text.rs
@@ -124,71 +124,61 @@ impl OrientedRect {
 /// How far apart two labels saying the same thing have to be.
 const MIN_REPEAT_DISTANCE: f32 = 400.0;
 
-/// Tracks what has been named where, so that a street arriving as a dozen features is not
-/// named a dozen times.
+/// What has been placed so far - where it sits, and what it says.
 ///
-/// Only line labels take part. OSM splits a way at every intersection, so one street really is
-/// many features saying the same thing, while two points sharing a name are two different
-/// things - house numbers being the obvious case.
+/// Only line labels are remembered by name. OSM splits a way at every intersection, so one
+/// street really is many features saying the same thing, while two points sharing a name are two
+/// different things - house numbers being the obvious case.
 #[derive(Default)]
-struct PlacedLabels {
-    positions: HashMap<String, Vec<Pos2>>,
+struct PlacedTexts {
+    occupied_areas: Vec<OrientedRect>,
+    text_positions: HashMap<String, Vec<Pos2>>,
 }
 
-impl PlacedLabels {
-    fn text_already_placed_nearby(&self, text: &Text) -> bool {
+impl PlacedTexts {
+    fn already_placed_nearby(&self, text: &Text) -> bool {
         text.placement == Placement::Line
-            && self.positions.get(&text.text).is_some_and(|positions| {
-                positions
-                    .iter()
-                    .any(|placed| placed.distance(text.position) < MIN_REPEAT_DISTANCE)
-            })
+            && self
+                .text_positions
+                .get(&text.text)
+                .is_some_and(|positions| {
+                    positions
+                        .iter()
+                        .any(|placed| placed.distance(text.position) < MIN_REPEAT_DISTANCE)
+                })
     }
 
-    fn remember(&mut self, text: &Text) {
-        if text.placement != Placement::Line {
-            return;
+    /// Take the area, unless something is already there. The text is remembered only once it
+    /// turned out to be free.
+    fn try_place(&mut self, text: &Text, area: OrientedRect) -> bool {
+        if self
+            .occupied_areas
+            .iter()
+            .any(|occupied| occupied.intersects(&area))
+        {
+            return false;
         }
 
-        self.positions
-            .entry(text.text.to_owned())
-            .or_default()
-            .push(text.position);
-    }
-}
+        self.occupied_areas.push(area);
 
-// Tracks areas occupied by texts to avoid overlapping them.
-pub struct OccupiedAreas {
-    areas: Vec<OrientedRect>,
-}
-
-impl OccupiedAreas {
-    pub fn new() -> Self {
-        Self { areas: Vec::new() }
-    }
-
-    pub fn try_occupy(&mut self, rect: OrientedRect) -> bool {
-        if !self.areas.iter().any(|existing| existing.intersects(&rect)) {
-            self.areas.push(rect);
-            true
-        } else {
-            false
+        if text.placement == Placement::Line {
+            self.text_positions
+                .entry(text.text.to_owned())
+                .or_default()
+                .push(text.position);
         }
+
+        true
     }
 }
 
 /// Lay the text out, unless it repeats a nearby one or would land on an area which is already
 /// taken.
-fn place_text(
-    text: Text,
-    ctx: &egui::Context,
-    occupied_areas: &mut OccupiedAreas,
-    placed_labels: &mut PlacedLabels,
-) -> Shape {
+fn place_text(text: Text, ctx: &egui::Context, placed_texts: &mut PlacedTexts) -> Shape {
     use egui::epaint::TextShape;
 
     // Before laying it out, which is the expensive part.
-    if placed_labels.text_already_placed_nearby(&text) {
+    if placed_texts.already_placed_nearby(&text) {
         return Shape::Noop;
     }
 
@@ -209,11 +199,9 @@ fn place_text(
     let area = OrientedRect::new(text.position, text.angle, galley.size());
     let top_left = area.top_left();
 
-    if !occupied_areas.try_occupy(area) {
+    if !placed_texts.try_place(&text, area) {
         return Shape::Noop;
     }
-
-    placed_labels.remember(&text);
 
     let on_top =
         TextShape::new(top_left, galley.to_owned(), text.text_color).with_angle(text.angle);
@@ -244,13 +232,12 @@ fn place_text(
 /// Lay out the labels, dropping the ones which repeat a nearby label or would land on top of an
 /// already placed one.
 pub fn place_texts(texts: Vec<Text>, ctx: &egui::Context) -> Vec<Shape> {
-    let mut occupied_areas = OccupiedAreas::new();
-    let mut placed_labels = PlacedLabels::default();
+    let mut placed_texts = PlacedTexts::default();
 
     // Need to collect it to avoid deadlock caused by `Painter::extend` and `fonts_mut`.
     texts
         .into_iter()
-        .map(|text| place_text(text, ctx, &mut occupied_areas, &mut placed_labels))
+        .map(|text| place_text(text, ctx, &mut placed_texts))
         .collect()
 }
 


### PR DESCRIPTION
OSM splits a way at every intersection, so one street arrives as many features and each got its own label. Line labels are now dropped when the same name was already placed within 400px.

Point labels are left alone - two of them sharing a name are two different things, house numbers being the obvious case. They still get culled by collision as before.

`OccupiedAreas` and the new repeat state are merged into one `PlacedTexts`, so `try_place` takes the area and remembers the name together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)